### PR TITLE
Patch insolvency endpoint created

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <cucumber.version>7.2.3</cucumber.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
         <springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>
-        <private-api-sdk-java.version>2.0.119</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.122</private-api-sdk-java.version>
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <cucumber.version>7.2.3</cucumber.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
         <springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>
-        <private-api-sdk-java.version>2.0.122</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.119</private-api-sdk-java.version>
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
 
@@ -254,13 +254,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit47</artifactId>
-                        <version>${maven-surefire-plugin.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <excludes>
                         <exclude>**/*ITest.java</exclude>

--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
@@ -64,7 +64,7 @@ public class CompanyProfileControllerITest {
 
     @Test
     @DisplayName("PATCH insolvency links")
-    void patchInsolvencyLinks() {
+    void patchInsolvencyLinks() throws Exception {
         CompanyProfile mockCompanyProfile = new CompanyProfile();
         Data companyData = new Data().companyNumber(MOCK_COMPANY_NUMBER);
         mockCompanyProfile.setData(companyData);

--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
@@ -1,9 +1,12 @@
 package uk.gov.companieshouse.company.profile.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+
+import com.google.gson.Gson;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,12 +24,15 @@ import uk.gov.companieshouse.company.profile.service.CompanyProfileService;
 public class CompanyProfileControllerITest {
     private static final String MOCK_COMPANY_NUMBER = "6146287";
     private static final String COMPANY_URL = String.format("/company/%s", MOCK_COMPANY_NUMBER);
+    private static final String PATCH_INSOLVENCY_URL = String.format("/company/%s/links", MOCK_COMPANY_NUMBER);
 
     @MockBean
     private CompanyProfileService companyProfileService;
 
     @Autowired
     private TestRestTemplate restTemplate;
+
+    Gson gson = new Gson();
 
     @Test
     @DisplayName("Retrieve a company profile containing a given company number")
@@ -55,5 +61,22 @@ public class CompanyProfileControllerITest {
 
         assertThat(companyProfileResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         assertThat(companyProfileResponse.getBody()).isNull();
+    }
+
+    @Test
+    @DisplayName("PATCH insolvency links")
+    void patchInsolvencyLinks() throws Exception {
+        CompanyProfile mockCompanyProfile = new CompanyProfile();
+        Data companyData = new Data().companyNumber(MOCK_COMPANY_NUMBER);
+        mockCompanyProfile.setData(companyData);
+        CompanyProfileDao mockCompanyProfileDao = new CompanyProfileDao(mockCompanyProfile);
+
+
+        doNothing().when(companyProfileService).update(mockCompanyProfile);
+
+        String companyProfileResponse =
+                restTemplate.patchForObject(PATCH_INSOLVENCY_URL, mockCompanyProfile, String.class);
+
+        assertThat(companyProfileResponse.equals("OK"));
     }
 }

--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
@@ -13,6 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.company.CompanyProfile;
@@ -65,18 +67,17 @@ public class CompanyProfileControllerITest {
 
     @Test
     @DisplayName("PATCH insolvency links")
-    void patchInsolvencyLinks() throws Exception {
+    void patchInsolvencyLinks() {
         CompanyProfile mockCompanyProfile = new CompanyProfile();
         Data companyData = new Data().companyNumber(MOCK_COMPANY_NUMBER);
         mockCompanyProfile.setData(companyData);
-        CompanyProfileDao mockCompanyProfileDao = new CompanyProfileDao(mockCompanyProfile);
+        doNothing().when(companyProfileService).updateInsolvencyLink(mockCompanyProfile);
 
+        HttpEntity<CompanyProfile> httpEntity = new HttpEntity<>(mockCompanyProfile, null);
+        ResponseEntity<Void> responseEntity = restTemplate.exchange(
+                PATCH_INSOLVENCY_URL,
+                HttpMethod.PATCH, httpEntity, Void.class);
 
-        doNothing().when(companyProfileService).update(mockCompanyProfile);
-
-        String companyProfileResponse =
-                restTemplate.patchForObject(PATCH_INSOLVENCY_URL, mockCompanyProfile, String.class);
-
-        assertThat(companyProfileResponse.equals("OK"));
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 }

--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import com.google.gson.Gson;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
-import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
+import uk.gov.companieshouse.company.profile.model.CompanyProfileDocument;
 import uk.gov.companieshouse.company.profile.service.CompanyProfileService;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -40,9 +39,9 @@ public class CompanyProfileControllerITest {
         CompanyProfile mockCompanyProfile = new CompanyProfile();
         Data companyData = new Data().companyNumber(MOCK_COMPANY_NUMBER);
         mockCompanyProfile.setData(companyData);
-        CompanyProfileDao mockCompanyProfileDao = new CompanyProfileDao(mockCompanyProfile);
+        CompanyProfileDocument mockCompanyProfileDocument = new CompanyProfileDocument(mockCompanyProfile);
 
-        when(companyProfileService.get(MOCK_COMPANY_NUMBER)).thenReturn(Optional.of(mockCompanyProfileDao));
+        when(companyProfileService.get(MOCK_COMPANY_NUMBER)).thenReturn(Optional.of(mockCompanyProfileDocument));
 
         ResponseEntity<CompanyProfile> companyProfileResponse =
                 restTemplate.getForEntity(COMPANY_URL, CompanyProfile.class);

--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
@@ -2,8 +2,10 @@ package uk.gov.companieshouse.company.profile.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -76,5 +78,22 @@ public class CompanyProfileControllerITest {
                 HttpMethod.PATCH, httpEntity, Void.class);
 
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("PATCH insolvency links NOT FOUND")
+    void patchInsolvencyLinksNotFound() throws Exception {
+        CompanyProfile mockCompanyProfile = new CompanyProfile();
+        Data companyData = new Data().companyNumber(MOCK_COMPANY_NUMBER);
+        mockCompanyProfile.setData(companyData);
+        doThrow(new NoSuchElementException()).when(companyProfileService).updateInsolvencyLink(mockCompanyProfile);
+
+        HttpEntity<CompanyProfile> httpEntity = new HttpEntity<>(mockCompanyProfile, null);
+        ResponseEntity<Void> responseEntity = restTemplate.exchange(
+                PATCH_INSOLVENCY_URL,
+                HttpMethod.PATCH, httpEntity, Void.class);
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(responseEntity.getBody()).isNull();
     }
 }

--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
@@ -34,8 +34,6 @@ public class CompanyProfileControllerITest {
     @Autowired
     private TestRestTemplate restTemplate;
 
-    Gson gson = new Gson();
-
     @Test
     @DisplayName("Retrieve a company profile containing a given company number")
     void getCompanyProfileWithMatchingCompanyNumber() throws Exception {

--- a/src/itest/java/uk/gov/companieshouse/company/profile/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/repository/RepositoryITest.java
@@ -24,8 +24,6 @@ class RepositoryITest {
 
     private static final String MOCK_COMPANY_NUMBER = "6146287";
 
-    Gson gson = new Gson();
-
     // static, so container starts before the application context and we can set properties
     @Container
     static MongoDBContainer mongoDBContainer = new MongoDBContainer(

--- a/src/itest/java/uk/gov/companieshouse/company/profile/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/repository/RepositoryITest.java
@@ -86,8 +86,6 @@ class RepositoryITest {
 
         this.companyProfileRepository.save(companyProfileDao);
 
-        System.out.println(this.companyProfileRepository.findAll().get(0));
-
         CompanyProfileDao companyProfileRetrievedFromDB = this.companyProfileRepository.findByCompanyNumber(MOCK_COMPANY_NUMBER);
         assert(gson.toJson(companyProfileRetrievedFromDB)).equals(gson.toJson(companyProfileDao));
     }

--- a/src/itest/java/uk/gov/companieshouse/company/profile/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/repository/RepositoryITest.java
@@ -1,6 +1,9 @@
 package uk.gov.companieshouse.company.profile.repository;
 
+import com.google.gson.Gson;
+import org.junit.Before;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
@@ -21,6 +24,8 @@ class RepositoryITest {
 
     private static final String MOCK_COMPANY_NUMBER = "6146287";
 
+    Gson gson = new Gson();
+
     // static, so container starts before the application context and we can set properties
     @Container
     static MongoDBContainer mongoDBContainer = new MongoDBContainer(
@@ -34,6 +39,10 @@ class RepositoryITest {
     @Autowired
     private CompanyProfileRepository companyProfileRepository;
 
+    @BeforeEach
+    void setup() {
+        this.companyProfileRepository.deleteAll();
+    }
 
     @Test
     void should_return_mongodb_as_running() {
@@ -66,6 +75,21 @@ class RepositoryITest {
 
         Assertions.assertTrue(
                 this.companyProfileRepository.findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber("othernumber").isEmpty());
+    }
+
+    @Test
+    void should_return_company_profile_based_on_company_number() {
+        CompanyProfile companyProfile = new CompanyProfile();
+        Data companyData = new Data().companyNumber(MOCK_COMPANY_NUMBER);
+        companyProfile.setData(companyData);
+        CompanyProfileDao companyProfileDao = new CompanyProfileDao(companyProfile);
+
+        this.companyProfileRepository.save(companyProfileDao);
+
+        System.out.println(this.companyProfileRepository.findAll().get(0));
+
+        CompanyProfileDao companyProfileRetrievedFromDB = this.companyProfileRepository.findByCompanyNumber(MOCK_COMPANY_NUMBER);
+        assert(gson.toJson(companyProfileRetrievedFromDB)).equals(gson.toJson(companyProfileDao));
     }
 
 }

--- a/src/itest/java/uk/gov/companieshouse/company/profile/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/repository/RepositoryITest.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.company.profile.repository;
 
-import com.google.gson.Gson;
-import org.junit.Before;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,7 +14,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
-import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
+import uk.gov.companieshouse.company.profile.model.CompanyProfileDocument;
 
 @Testcontainers
 @DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
@@ -52,9 +50,9 @@ class RepositoryITest {
         CompanyProfile companyProfile = new CompanyProfile();
         Data companyData = new Data().companyNumber(MOCK_COMPANY_NUMBER);
         companyProfile.setData(companyData);
-        CompanyProfileDao companyProfileDao = new CompanyProfileDao(companyProfile);
+        CompanyProfileDocument companyProfileDocument = new CompanyProfileDocument(companyProfile);
 
-        this.companyProfileRepository.save(companyProfileDao);
+        this.companyProfileRepository.save(companyProfileDocument);
 
         System.out.println(this.companyProfileRepository.findAll().get(0));
 
@@ -67,9 +65,9 @@ class RepositoryITest {
         CompanyProfile companyProfile = new CompanyProfile();
         Data companyData = new Data().companyNumber("242424");
         companyProfile.setData(companyData);
-        CompanyProfileDao companyProfileDao = new CompanyProfileDao(companyProfile);
+        CompanyProfileDocument companyProfileDocument = new CompanyProfileDocument(companyProfile);
 
-        this.companyProfileRepository.save(companyProfileDao);
+        this.companyProfileRepository.save(companyProfileDocument);
 
         Assertions.assertTrue(
                 this.companyProfileRepository.findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber("othernumber").isEmpty());

--- a/src/itest/java/uk/gov/companieshouse/company/profile/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/repository/RepositoryITest.java
@@ -77,17 +77,4 @@ class RepositoryITest {
                 this.companyProfileRepository.findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber("othernumber").isEmpty());
     }
 
-    @Test
-    void should_return_company_profile_based_on_company_number() {
-        CompanyProfile companyProfile = new CompanyProfile();
-        Data companyData = new Data().companyNumber(MOCK_COMPANY_NUMBER);
-        companyProfile.setData(companyData);
-        CompanyProfileDao companyProfileDao = new CompanyProfileDao(companyProfile);
-
-        this.companyProfileRepository.save(companyProfileDao);
-
-        CompanyProfileDao companyProfileRetrievedFromDB = this.companyProfileRepository.findByCompanyNumber(MOCK_COMPANY_NUMBER);
-        assert(gson.toJson(companyProfileRetrievedFromDB)).equals(gson.toJson(companyProfileDao));
-    }
-
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
@@ -35,11 +35,11 @@ public class CompanyProfileController {
     }
 
     @PatchMapping("/company/{company_number}/links")
-    public ResponseEntity<String> updateCompanyProfile(
+    public ResponseEntity<Void> updateCompanyProfile(
             @PathVariable("company_number") String companyNumber,
             @RequestBody CompanyProfile requestBody
     ) {
-        companyProfileService.update(requestBody);
-        return ResponseEntity.status(HttpStatus.OK).body("OK");
+        companyProfileService.updateInsolvencyLink(requestBody);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.company.profile.controller;
 
+import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,12 +35,23 @@ public class CompanyProfileController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    /**
+     * Update a company insolvency link.
+     *
+     * @param companyNumber the company number of the company
+     * @param requestBody The company profile
+     */
     @PatchMapping("/company/{company_number}/links")
     public ResponseEntity<Void> updateCompanyProfile(
             @PathVariable("company_number") String companyNumber,
             @RequestBody CompanyProfile requestBody
     ) {
-        companyProfileService.updateInsolvencyLink(requestBody);
-        return ResponseEntity.status(HttpStatus.OK).build();
+        try {
+            companyProfileService.updateInsolvencyLink(requestBody);
+            return ResponseEntity.status(HttpStatus.OK).build();
+        } catch (NoSuchElementException noSuchElementException) {
+            return ResponseEntity.notFound().build();
+        }
+
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
@@ -3,7 +3,9 @@ package uk.gov.companieshouse.company.profile.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.company.profile.service.CompanyProfileService;
@@ -30,5 +32,14 @@ public class CompanyProfileController {
                 .map(companyProfileDao ->
                         new ResponseEntity<>(companyProfileDao.companyProfile, HttpStatus.OK))
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/company/{company_number}/links")
+    public ResponseEntity<String> updateCompanyProfile(
+            @PathVariable("company_number") String companyNumber,
+            @RequestBody CompanyProfile requestBody
+    ) {
+        companyProfileService.update(requestBody);
+        return ResponseEntity.status(HttpStatus.OK).body("OK");
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/model/CompanyProfileDocument.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/model/CompanyProfileDocument.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.company.profile.domain;
+package uk.gov.companieshouse.company.profile.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -8,7 +8,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 
 @Document(collection = "company_profile")
-public class CompanyProfileDao {
+public class CompanyProfileDocument {
     @Id
     @JsonIgnore
     private ObjectId id;
@@ -16,7 +16,7 @@ public class CompanyProfileDao {
     @JsonProperty("companyProfile")
     public CompanyProfile companyProfile;
 
-    public CompanyProfileDao(CompanyProfile companyProfile) {
+    public CompanyProfileDocument(CompanyProfile companyProfile) {
         this.companyProfile = companyProfile;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/repository/CompanyProfileRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/repository/CompanyProfileRepository.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.company.profile.repository;
 
 import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
 import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
 
 public interface CompanyProfileRepository extends MongoRepository<CompanyProfileDao, String> {

--- a/src/main/java/uk/gov/companieshouse/company/profile/repository/CompanyProfileRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/repository/CompanyProfileRepository.java
@@ -2,9 +2,13 @@ package uk.gov.companieshouse.company.profile.repository;
 
 import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
 
 public interface CompanyProfileRepository extends MongoRepository<CompanyProfileDao, String> {
+    @Query("{'companyProfile.data.companyNumber':?0}")
+    CompanyProfileDao findByCompanyNumber(String companyNumber);
+
     // company number is not a direct property of the entity so traversal is required
     Optional<CompanyProfileDao> findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(
             String companyNumber);

--- a/src/main/java/uk/gov/companieshouse/company/profile/repository/CompanyProfileRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/repository/CompanyProfileRepository.java
@@ -6,9 +6,6 @@ import org.springframework.data.mongodb.repository.Query;
 import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
 
 public interface CompanyProfileRepository extends MongoRepository<CompanyProfileDao, String> {
-    @Query("{'companyProfile.data.companyNumber':?0}")
-    CompanyProfileDao findByCompanyNumber(String companyNumber);
-
     // company number is not a direct property of the entity so traversal is required
     Optional<CompanyProfileDao> findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(
             String companyNumber);

--- a/src/main/java/uk/gov/companieshouse/company/profile/repository/CompanyProfileRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/repository/CompanyProfileRepository.java
@@ -2,10 +2,10 @@ package uk.gov.companieshouse.company.profile.repository;
 
 import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
+import uk.gov.companieshouse.company.profile.model.CompanyProfileDocument;
 
-public interface CompanyProfileRepository extends MongoRepository<CompanyProfileDao, String> {
+public interface CompanyProfileRepository extends MongoRepository<CompanyProfileDocument, String> {
     // company number is not a direct property of the entity so traversal is required
-    Optional<CompanyProfileDao> findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(
+    Optional<CompanyProfileDocument> findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(
             String companyNumber);
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.company.profile.service;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.company.CompanyProfile;
-import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
+import uk.gov.companieshouse.company.profile.model.CompanyProfileDocument;
 import uk.gov.companieshouse.company.profile.repository.CompanyProfileRepository;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -25,9 +25,9 @@ public class CompanyProfileService {
      * @return a company profile if one with such a company number exists, otherwise an empty
      *     optional
      */
-    public Optional<CompanyProfileDao> get(String companyNumber) {
+    public Optional<CompanyProfileDocument> get(String companyNumber) {
         logger.trace(String.format("DSND-374: GET company profile with number %s", companyNumber));
-        Optional<CompanyProfileDao> companyProfileDao = companyProfileRepository
+        Optional<CompanyProfileDocument> companyProfileDao = companyProfileRepository
                 .findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(companyNumber);
 
         logger.trace(String.format("DSND-374: Company profile with number %s retrieved: %s",
@@ -40,7 +40,7 @@ public class CompanyProfileService {
      * @param companyProfileRequest company Profile information {@link CompanyProfile}
      */
     public void updateInsolvencyLink(final CompanyProfile companyProfileRequest) {
-        CompanyProfileDao companyProfile = companyProfileRepository
+        CompanyProfileDocument companyProfile = companyProfileRepository
                 .findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(
                         companyProfileRequest.getData().getCompanyNumber()).get();
         String insolvencyLink = companyProfileRequest.getData().getLinks().getInsolvency();

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -39,13 +39,14 @@ public class CompanyProfileService {
      * Updated insolvency links in company profile.
      * @param companyProfileRequest company Profile information {@link CompanyProfile}
      */
-    public void update(final CompanyProfile companyProfileRequest) {
+    public void updateInsolvencyLink(final CompanyProfile companyProfileRequest) {
         CompanyProfileDao companyProfile = companyProfileRepository
-                .findByCompanyNumber(companyProfileRequest.getData().getCompanyNumber());
+                .findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(
+                        companyProfileRequest.getData().getCompanyNumber()).get();
         String insolvencyLink = companyProfileRequest.getData().getLinks().getInsolvency();
         companyProfile.companyProfile.getData().getLinks().setInsolvency(insolvencyLink);
         companyProfileRepository.save(companyProfile);
-        logger.debug(String.format("Data saved in company_profile collection : %s",
+        logger.trace(String.format("DSND-376: Insolvency links updated: %s",
                 companyProfileRequest.toString()));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company.profile.service;
 
 import java.util.Optional;
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
 import uk.gov.companieshouse.company.profile.repository.CompanyProfileRepository;
 import uk.gov.companieshouse.logging.Logger;
@@ -32,5 +33,19 @@ public class CompanyProfileService {
         logger.trace(String.format("DSND-374: Company profile with number %s retrieved: %s",
                 companyNumber, companyProfileDao));
         return companyProfileDao;
+    }
+
+    /**
+     * Updated insolvency links in company profile.
+     * @param companyProfileRequest company Profile information {@link CompanyProfile}
+     */
+    public void update(final CompanyProfile companyProfileRequest) {
+        CompanyProfileDao companyProfile = companyProfileRepository
+                .findByCompanyNumber(companyProfileRequest.getData().getCompanyNumber());
+        String insolvencyLink = companyProfileRequest.getData().getLinks().getInsolvency();
+        companyProfile.companyProfile.getData().getLinks().setInsolvency(insolvencyLink);
+        companyProfileRepository.save(companyProfile);
+        logger.debug(String.format("Data saved in company_profile collection : %s",
+                companyProfileRequest.toString()));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.company.profile.service;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.company.CompanyProfile;
@@ -39,10 +40,17 @@ public class CompanyProfileService {
      * Updated insolvency links in company profile.
      * @param companyProfileRequest company Profile information {@link CompanyProfile}
      */
-    public void updateInsolvencyLink(final CompanyProfile companyProfileRequest) {
-        CompanyProfileDocument companyProfile = companyProfileRepository
+    public void updateInsolvencyLink(final CompanyProfile companyProfileRequest)
+            throws NoSuchElementException {
+        Optional<CompanyProfileDocument> companyProfileOptional = companyProfileRepository
                 .findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(
-                        companyProfileRequest.getData().getCompanyNumber()).get();
+                        companyProfileRequest.getData().getCompanyNumber());
+
+        if (companyProfileOptional.isEmpty()) {
+            throw new NoSuchElementException("Database entry not found");
+        }
+
+        CompanyProfileDocument companyProfile = companyProfileOptional.get();
         String insolvencyLink = companyProfileRequest.getData().getLinks().getInsolvency();
         companyProfile.companyProfile.getData().getLinks().setInsolvency(insolvencyLink);
         companyProfileRepository.save(companyProfile);

--- a/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
 
 import com.google.gson.Gson;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,7 +24,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
 import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
@@ -92,8 +90,10 @@ class CompanyProfileControllerTest {
     @DisplayName("Company Profile PATCH request")
     public void callCompanyProfilePatch() throws Exception {
         CompanyProfile request = new CompanyProfile();
-        doNothing().when(companyProfileService).update(isA(CompanyProfile.class));
         String url = String.format("/company/%s/links", "02588581");
+
+        doNothing().when(companyProfileService).updateInsolvencyLink(isA(CompanyProfile.class));
+
         mockMvc.perform(patch(url).contentType(APPLICATION_JSON)
                 .content(gson.toJson(request))).andExpect(status().isOk());
     }

--- a/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.company.profile.controller;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -12,6 +13,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import com.google.gson.Gson;
@@ -96,5 +99,17 @@ class CompanyProfileControllerTest {
 
         mockMvc.perform(patch(url).contentType(APPLICATION_JSON)
                 .content(gson.toJson(request))).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Company Profile PATCH request, not found")
+    public void callCompanyProfilePatchNotFound() throws Exception {
+        CompanyProfile request = new CompanyProfile();
+        String url = String.format("/company/%s/links", "02588581");
+
+        doThrow(new NoSuchElementException()).when(companyProfileService).updateInsolvencyLink(any());
+
+        mockMvc.perform(patch(url).contentType(APPLICATION_JSON)
+                .content(gson.toJson(request))).andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
-import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
+import uk.gov.companieshouse.company.profile.model.CompanyProfileDocument;
 import uk.gov.companieshouse.company.profile.service.CompanyProfileService;
 
 // Need to set context configuration otherwise non-dependent beans (the repository) will be created.
@@ -54,9 +54,9 @@ class CompanyProfileControllerTest {
         CompanyProfile mockCompanyProfile = new CompanyProfile();
         Data companyData = new Data().companyNumber(MOCK_COMPANY_NUMBER);
         mockCompanyProfile.setData(companyData);
-        CompanyProfileDao mockCompanyProfileDao = new CompanyProfileDao(mockCompanyProfile);
+        CompanyProfileDocument mockCompanyProfileDocument = new CompanyProfileDocument(mockCompanyProfile);
 
-        when(companyProfileService.get(MOCK_COMPANY_NUMBER)).thenReturn(Optional.of(mockCompanyProfileDao));
+        when(companyProfileService.get(MOCK_COMPANY_NUMBER)).thenReturn(Optional.of(mockCompanyProfileDocument));
 
         mockMvc.perform(get(COMPANY_URL))
                 .andExpect(status().isOk())

--- a/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
@@ -2,13 +2,20 @@ package uk.gov.companieshouse.company.profile.controller;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +25,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
 import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
@@ -39,6 +47,8 @@ class CompanyProfileControllerTest {
 
     @MockBean
     private CompanyProfileService companyProfileService;
+
+    private Gson gson = new Gson();
 
     @Test
     @DisplayName("Retrieve a company profile containing a given company number")
@@ -76,5 +86,15 @@ class CompanyProfileControllerTest {
                         .andExpect(status().isInternalServerError())
                         .andExpect(content().string(""))
         ).hasCause(new RuntimeException());
+    }
+
+    @Test
+    @DisplayName("Company Profile PATCH request")
+    public void callCompanyProfilePatch() throws Exception {
+        CompanyProfile request = new CompanyProfile();
+        doNothing().when(companyProfileService).update(isA(CompanyProfile.class));
+        String url = String.format("/company/%s/links", "02588581");
+        mockMvc.perform(patch(url).contentType(APPLICATION_JSON)
+                .content(gson.toJson(request))).andExpect(status().isOk());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -21,7 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
 import uk.gov.companieshouse.api.company.Links;
-import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
+import uk.gov.companieshouse.company.profile.model.CompanyProfileDocument;
 import uk.gov.companieshouse.company.profile.repository.CompanyProfileRepository;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -44,15 +44,15 @@ class CompanyProfileServiceTest {
         CompanyProfile mockCompanyProfile = new CompanyProfile();
         Data companyData = new Data().companyNumber(MOCK_COMPANY_NUMBER);
         mockCompanyProfile.setData(companyData);
-        CompanyProfileDao mockCompanyProfileDao = new CompanyProfileDao(mockCompanyProfile);
+        CompanyProfileDocument mockCompanyProfileDocument = new CompanyProfileDocument(mockCompanyProfile);
 
         when(companyProfileRepository.findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(anyString()))
-                .thenReturn(Optional.of(mockCompanyProfileDao));
+                .thenReturn(Optional.of(mockCompanyProfileDocument));
 
-        Optional<CompanyProfileDao> companyProfileActual =
+        Optional<CompanyProfileDocument> companyProfileActual =
                 companyProfileService.get(MOCK_COMPANY_NUMBER);
 
-        assertThat(companyProfileActual.get()).isSameAs(mockCompanyProfileDao);
+        assertThat(companyProfileActual.get()).isSameAs(mockCompanyProfileDocument);
         verify(logger, times(2)).trace(anyString());
     }
 
@@ -62,7 +62,7 @@ class CompanyProfileServiceTest {
         when(companyProfileRepository.findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(anyString()))
                 .thenReturn(Optional.empty());
 
-        Optional<CompanyProfileDao> companyProfileActual =
+        Optional<CompanyProfileDocument> companyProfileActual =
                 companyProfileService.get(MOCK_COMPANY_NUMBER);
 
         assertTrue(companyProfileActual.isEmpty());
@@ -75,7 +75,7 @@ class CompanyProfileServiceTest {
         CompanyProfile companyProfile = mockCompanyProfileWithoutInsolvency();
         CompanyProfile companyProfileWithInsolvency = companyProfile;
         companyProfileWithInsolvency.getData().getLinks().setInsolvency("INSOLVENCY_LINK");
-        when(companyProfileRepository.findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(any())).thenReturn(Optional.of(new CompanyProfileDao(companyProfile)));
+        when(companyProfileRepository.findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(any())).thenReturn(Optional.of(new CompanyProfileDocument(companyProfile)));
 
         companyProfileService.updateInsolvencyLink(companyProfileWithInsolvency);
 

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -3,17 +3,20 @@ package uk.gov.companieshouse.company.profile.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.any;
 
 import java.util.Optional;
 
-import org.junit.Before;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
@@ -34,12 +37,6 @@ class CompanyProfileServiceTest {
 
     @InjectMocks
     CompanyProfileService companyProfileService;
-
-
-    @Before
-    void setup() {
-        doNothing().when(logger).debug(Mockito.any());
-    }
 
     @Test
     @DisplayName("When company profile is retrieved successfully then it is returned")
@@ -78,12 +75,12 @@ class CompanyProfileServiceTest {
         CompanyProfile companyProfile = mockCompanyProfileWithoutInsolvency();
         CompanyProfile companyProfileWithInsolvency = companyProfile;
         companyProfileWithInsolvency.getData().getLinks().setInsolvency("INSOLVENCY_LINK");
-        when(companyProfileRepository.findByCompanyNumber(Mockito.any())).thenReturn(new CompanyProfileDao(companyProfile));
+        when(companyProfileRepository.findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(any())).thenReturn(Optional.of(new CompanyProfileDao(companyProfile)));
 
-        companyProfileService.update(companyProfileWithInsolvency);
+        companyProfileService.updateInsolvencyLink(companyProfileWithInsolvency);
 
-        verify(companyProfileRepository, Mockito.times(1)).findByCompanyNumber(eq(companyProfile.getData().getCompanyNumber()));
-        verify(companyProfileRepository, Mockito.times(1)).save(argThat(companyProfileDao -> {
+        verify(companyProfileRepository, times(1)).findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(eq(companyProfile.getData().getCompanyNumber()));
+        verify(companyProfileRepository, times(1)).save(argThat(companyProfileDao -> {
             assert(companyProfileDao.companyProfile.getData().getLinks().getInsolvency()).equals(companyProfileWithInsolvency.getData().getLinks().getInsolvency());
             return true;
         }));

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -3,19 +3,21 @@ package uk.gov.companieshouse.company.profile.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Optional;
+
+import org.junit.Before;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
+import uk.gov.companieshouse.api.company.Links;
 import uk.gov.companieshouse.company.profile.domain.CompanyProfileDao;
 import uk.gov.companieshouse.company.profile.repository.CompanyProfileRepository;
 import uk.gov.companieshouse.logging.Logger;
@@ -32,6 +34,12 @@ class CompanyProfileServiceTest {
 
     @InjectMocks
     CompanyProfileService companyProfileService;
+
+
+    @Before
+    void setup() {
+        doNothing().when(logger).debug(Mockito.any());
+    }
 
     @Test
     @DisplayName("When company profile is retrieved successfully then it is returned")
@@ -62,5 +70,35 @@ class CompanyProfileServiceTest {
 
         assertTrue(companyProfileActual.isEmpty());
         verify(logger, times(2)).trace(anyString());
+    }
+
+
+    @Test
+    void when_insolvency_data_is_given_then_data_should_be_saved() {
+        CompanyProfile companyProfile = mockCompanyProfileWithoutInsolvency();
+        CompanyProfile companyProfileWithInsolvency = companyProfile;
+        companyProfileWithInsolvency.getData().getLinks().setInsolvency("INSOLVENCY_LINK");
+        when(companyProfileRepository.findByCompanyNumber(Mockito.any())).thenReturn(new CompanyProfileDao(companyProfile));
+
+        companyProfileService.update(companyProfileWithInsolvency);
+
+        verify(companyProfileRepository, Mockito.times(1)).findByCompanyNumber(eq(companyProfile.getData().getCompanyNumber()));
+        verify(companyProfileRepository, Mockito.times(1)).save(argThat(companyProfileDao -> {
+            assert(companyProfileDao.companyProfile.getData().getLinks().getInsolvency()).equals(companyProfileWithInsolvency.getData().getLinks().getInsolvency());
+            return true;
+        }));
+    }
+
+    private CompanyProfile mockCompanyProfileWithoutInsolvency() {
+        CompanyProfile companyProfile = new CompanyProfile();
+        Data data = new Data();
+        data.setCompanyNumber("12345");
+
+        Links links = new Links();
+        links.setOfficers("officer");
+
+        data.setLinks(links);
+        companyProfile.setData(data);
+        return companyProfile;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -71,7 +71,7 @@ class CompanyProfileServiceTest {
 
 
     @Test
-    void when_insolvency_data_is_given_then_data_should_be_saved() {
+    void when_insolvency_data_is_given_then_data_should_be_saved() throws Exception {
         CompanyProfile companyProfile = mockCompanyProfileWithoutInsolvency();
         CompanyProfile companyProfileWithInsolvency = companyProfile;
         companyProfileWithInsolvency.getData().getLinks().setInsolvency("INSOLVENCY_LINK");

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.company.profile.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -10,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.any;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -67,6 +70,22 @@ class CompanyProfileServiceTest {
 
         assertTrue(companyProfileActual.isEmpty());
         verify(logger, times(2)).trace(anyString());
+    }
+
+    @Test
+    @DisplayName("When insolvency is given but company doesnt exist with that company number, NoSuchElementException exception thrown")
+    void when_insolvency_data_is_given_then_data_should_be_saved_not_found() {
+        CompanyProfile companyProfile = mockCompanyProfileWithoutInsolvency();
+        CompanyProfile companyProfileWithInsolvency = companyProfile;
+        companyProfileWithInsolvency.getData().getLinks().setInsolvency("INSOLVENCY_LINK");
+        when(companyProfileRepository.findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(any())).thenReturn(Optional.empty());
+
+        assertThrows(
+                NoSuchElementException.class,
+                () -> companyProfileService.updateInsolvencyLink(companyProfileWithInsolvency),
+                "Expected doThing() to throw, but it didn't"
+        );
+        verify(companyProfileRepository, times(1)).findCompanyProfileDaoByCompanyProfile_Data_CompanyNumber(eq(companyProfile.getData().getCompanyNumber()));
     }
 
 


### PR DESCRIPTION
DSND-376 - Created a PATCH endpoint to update the Insolvency Links field, found in Data -> Links -> Insolvency.
Complete payload will be sent to PATCH endpoint, and only the insolvency field is to be updated in the DB.
Mongo DB entry looks like so:
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/16381559/157227703-fa81d463-3db0-4369-9338-b0ff17bdf8f2.png">
