### PR TITLE
Update method now runs a single UPDATE query on mongoDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <docker-maven-plugin.version>1.0.0</docker-maven-plugin.version>
         <structured-logging.version>1.9.14</structured-logging.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
+        <api-helper-java.version>1.4.5</api-helper-java.version>
         <cucumber.version>7.2.3</cucumber.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
         <springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>
@@ -128,6 +129,11 @@
             <artifactId>cucumber-spring</artifactId>
             <version>${cucumber.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-helper-java</artifactId>
+            <version>${api-helper-java.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -8,13 +8,6 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-
-import com.mongodb.client.result.UpdateResult;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
 import uk.gov.companieshouse.api.company.CompanyProfile;
@@ -88,10 +81,15 @@ public class CompanyProfileService {
         if (updateResult.getModifiedCount() == 1) {
             logger.trace(String.format("DSND-376: Insolvency links updated for company number: %s",
                     companyNumber));
-            insolvencyApiService.invokeChsKafkaApi(companyNumber);
+            try {
+                insolvencyApiService.invokeChsKafkaApi(companyNumber);
+                logger.info(String.format("DSND-377: ChsKafka api invoked successfully for company "
+                        + "number %s", companyNumber));
+            } catch (Exception exception) {
+                logger.info(String.format("Error invoking ChsKafka API for company number %s",
+                        companyNumber));
+            }
 
-            logger.info(String.format("DSND-377: ChsKafka api invoked successfully for company "
-                    + "number %s", companyNumber));
         }
         if (updateResult.getMatchedCount() == 0) {
             throw new NoSuchElementException("Company profile not found");

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.company.profile.service;
 import com.mongodb.client.result.UpdateResult;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -16,6 +16,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.GenerateEtagUtil;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.company.profile.api.InsolvencyApiService;
 import uk.gov.companieshouse.company.profile.model.CompanyProfileDocument;
@@ -78,6 +79,8 @@ public class CompanyProfileService {
         Update updateQuery = new Update();
         updateQuery.set("data.links.insolvency",
                 companyProfileRequest.getData().getLinks().getInsolvency());
+        updateQuery.set("data.etag",
+                GenerateEtagUtil.generateEtag());
         UpdateResult updateResult = mongoTemplate.updateFirst(updateCriteria,
                 updateQuery,
                 "company_profile");

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -21,8 +21,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.gov.companieshouse.GenerateEtagUtil;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
 import uk.gov.companieshouse.api.company.Links;
@@ -101,7 +103,8 @@ class CompanyProfileServiceTest {
                     return true;
                 }
         ), argThat(updateQuery -> {
-            assert(updateQuery.getUpdateObject().toJson()).equals(expectedUpdateQuery(companyProfileWithInsolvency.getData().getLinks().getInsolvency()));
+            System.out.println(updateQuery.getUpdateObject().toJson());
+            assert(updateQuery.getUpdateObject().toJson()).contains(expectedUpdateQuery(companyProfileWithInsolvency.getData().getLinks().getInsolvency()));
             return true;
         }), eq(COMPANY_PROFILE_COLLECTION));
     }
@@ -121,7 +124,8 @@ class CompanyProfileServiceTest {
                     return true;
                 }
         ), argThat(updateQuery -> {
-            assert(updateQuery.getUpdateObject().toJson()).equals(expectedUpdateQuery(companyProfileWithInsolvency.getData().getLinks().getInsolvency()));
+            System.out.println(updateQuery.getUpdateObject().toJson());
+            assert(updateQuery.getUpdateObject().toJson()).contains(expectedUpdateQuery(companyProfileWithInsolvency.getData().getLinks().getInsolvency()));
             return true;
         }), eq(COMPANY_PROFILE_COLLECTION));
     }
@@ -144,6 +148,6 @@ class CompanyProfileServiceTest {
     }
 
     private String expectedUpdateQuery(String insolvencyLink) {
-        return String.format("{\"$set\": {\"data.links.insolvency\": \"%s\"}}", insolvencyLink);
+        return String.format("{\"$set\": {\"data.links.insolvency\": \"%s\", \"data.etag\": \"", insolvencyLink);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -1,17 +1,19 @@
 package uk.gov.companieshouse.company.profile.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
-
 import com.mongodb.client.result.UpdateResult;
 import com.mongodb.client.result.UpdateResult;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -1,25 +1,26 @@
 package uk.gov.companieshouse.company.profile.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.*;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
+import com.mongodb.client.result.UpdateResult;
+import com.mongodb.client.result.UpdateResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
 import uk.gov.companieshouse.api.company.Links;
@@ -32,8 +33,13 @@ import uk.gov.companieshouse.logging.Logger;
 class CompanyProfileServiceTest {
     private static final String MOCK_COMPANY_NUMBER = "6146287";
 
+    private static String COMPANY_PROFILE_COLLECTION = "company_profile";
+
     @Mock
     CompanyProfileRepository companyProfileRepository;
+
+    @Mock
+    MongoTemplate mongoTemplate;
 
     @Mock
     Logger logger;
@@ -80,37 +86,42 @@ class CompanyProfileServiceTest {
         CompanyProfile companyProfile = mockCompanyProfileWithoutInsolvency();
         CompanyProfile companyProfileWithInsolvency = companyProfile;
         companyProfileWithInsolvency.getData().getLinks().setInsolvency("INSOLVENCY_LINK");
-        when(companyProfileRepository.findById(any())).thenReturn(Optional.empty());
 
+        doReturn(UpdateResult.acknowledged(0l, 0l, null)).when(mongoTemplate).updateFirst(any(), any(), eq(COMPANY_PROFILE_COLLECTION));
         assertThrows(
                 NoSuchElementException.class,
                 () -> companyProfileService.updateInsolvencyLink(companyProfileWithInsolvency),
                 "Expected doThing() to throw, but it didn't"
         );
-        verify(companyProfileRepository, times(1)).findById(
-                eq(companyProfile.getData().getCompanyNumber()));
+
+        verify(mongoTemplate, times(1)).updateFirst(argThat(findQuery -> {
+                    assert(findQuery.getQueryObject().toJson()).equals(expectedFindQuery(companyProfileWithInsolvency.getData().getCompanyNumber()));
+                    return true;
+                }
+        ), argThat(updateQuery -> {
+            assert(updateQuery.getUpdateObject().toJson()).equals(expectedUpdateQuery(companyProfileWithInsolvency.getData().getLinks().getInsolvency()));
+            return true;
+        }), eq(COMPANY_PROFILE_COLLECTION));
     }
 
 
     @Test
     void when_insolvency_data_is_given_then_data_should_be_saved() throws Exception {
-        CompanyProfile companyProfileWithInsolvency = mockCompanyProfileWithoutInsolvency();
+        CompanyProfile companyProfile = mockCompanyProfileWithoutInsolvency();
+        CompanyProfile companyProfileWithInsolvency = companyProfile;
         companyProfileWithInsolvency.getData().getLinks().setInsolvency("INSOLVENCY_LINK");
-        CompanyProfileDocument mockCompanyProfileDocument = new CompanyProfileDocument(
-                companyProfileWithInsolvency.getData()
-        );
-        mockCompanyProfileDocument.setId(MOCK_COMPANY_NUMBER);
-
-        when(companyProfileRepository.findById(any())).thenReturn(
-                Optional.of(mockCompanyProfileDocument));
+        doReturn(UpdateResult.acknowledged(1l, 1l, null)).when(mongoTemplate).updateFirst(any(), any(), eq(COMPANY_PROFILE_COLLECTION));
 
         companyProfileService.updateInsolvencyLink(companyProfileWithInsolvency);
 
-        verify(companyProfileRepository, times(1)).findById(eq(MOCK_COMPANY_NUMBER));
-        verify(companyProfileRepository, times(1)).save(argThat(companyProfileDao -> {
-            assert(companyProfileDao.companyProfile.getLinks().getInsolvency()).equals(companyProfileWithInsolvency.getData().getLinks().getInsolvency());
+        verify(mongoTemplate, times(1)).updateFirst(argThat(findQuery -> {
+                    assert(findQuery.getQueryObject().toJson()).equals(expectedFindQuery(companyProfileWithInsolvency.getData().getCompanyNumber()));
+                    return true;
+                }
+        ), argThat(updateQuery -> {
+            assert(updateQuery.getUpdateObject().toJson()).equals(expectedUpdateQuery(companyProfileWithInsolvency.getData().getLinks().getInsolvency()));
             return true;
-        }));
+        }), eq(COMPANY_PROFILE_COLLECTION));
     }
 
     private CompanyProfile mockCompanyProfileWithoutInsolvency() {
@@ -124,5 +135,13 @@ class CompanyProfileServiceTest {
         data.setLinks(links);
         companyProfile.setData(data);
         return companyProfile;
+    }
+
+    private String expectedFindQuery(String companyNumber) {
+        return String.format("{\"data.company_number\": \"%s\"}", companyNumber);
+    }
+
+    private String expectedUpdateQuery(String insolvencyLink) {
+        return String.format("{\"$set\": {\"data.links.insolvency\": \"%s\"}}", insolvencyLink);
     }
 }


### PR DESCRIPTION
Fixed DSND-376 database persistence issue, improves database update performance (1 call instead of 2 calls before).
Now also updates Etag