### PR TITLE
DSND-929 - Return 410 when document is not found

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.company.profile.controller;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +12,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
+import uk.gov.companieshouse.company.profile.exception.DocumentGoneException;
 import uk.gov.companieshouse.company.profile.model.CompanyProfileDocument;
 import uk.gov.companieshouse.company.profile.model.Updated;
 import uk.gov.companieshouse.company.profile.service.CompanyProfileService;
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class CompanyProfileControllerITest {
+class CompanyProfileControllerITest {
     private static final String MOCK_COMPANY_NUMBER = "6146287";
     private static final String MOCK_CONTEXT_ID = "123456";
     private static final String COMPANY_URL = String.format("/company/%s/links",
@@ -82,7 +82,7 @@ public class CompanyProfileControllerITest {
     }
 
     @Test
-    @DisplayName("Return a not found response when company profile does not exist")
+    @DisplayName("Return a Resource Gone response when company profile does not exist")
     void getCompanyProfileWhenDoesNotExist() {
         when(companyProfileService.get(MOCK_COMPANY_NUMBER)).thenReturn(Optional.empty());
 
@@ -94,7 +94,7 @@ public class CompanyProfileControllerITest {
                 COMPANY_URL, HttpMethod.GET, new HttpEntity<Object>(headers),
                 CompanyProfile.class);
 
-        assertThat(companyProfileResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(companyProfileResponse.getStatusCode()).isEqualTo(HttpStatus.GONE);
         assertThat(companyProfileResponse.getBody()).isNull();
     }
 
@@ -144,12 +144,14 @@ public class CompanyProfileControllerITest {
     }
 
     @Test
-    @DisplayName("PATCH insolvency links NOT FOUND")
-    void patchInsolvencyLinksNotFound() throws Exception {
+    @DisplayName("PATCH insolvency links GONE")
+    void patchInsolvencyLinksGone() throws Exception {
         CompanyProfile mockCompanyProfile = new CompanyProfile();
         Data companyData = new Data().companyNumber(MOCK_COMPANY_NUMBER);
         mockCompanyProfile.setData(companyData);
-        doThrow(new NoSuchElementException()).when(companyProfileService).updateInsolvencyLink(MOCK_CONTEXT_ID, MOCK_COMPANY_NUMBER, mockCompanyProfile);
+        doThrow(new DocumentGoneException("Resource gone"))
+                .when(companyProfileService)
+                .updateInsolvencyLink(MOCK_CONTEXT_ID, MOCK_COMPANY_NUMBER, mockCompanyProfile);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -163,7 +165,7 @@ public class CompanyProfileControllerITest {
                 COMPANY_URL,
                 HttpMethod.PATCH, httpEntity, Void.class);
 
-        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.GONE);
         assertThat(responseEntity.getBody()).isNull();
     }
 }

--- a/src/itest/resources/features/company-profile-error-retry.feature
+++ b/src/itest/resources/features/company-profile-error-retry.feature
@@ -28,7 +28,7 @@ Feature: Error and retry scenarios for company profile
 
     Given Company profile api service is running
     When I send GET request with company number "<data>"
-    Then I should receive 404 status code
+    Then I should receive 410 status code
 
     Examples:
       | data     |

--- a/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.company.profile.controller;
 
-import java.util.NoSuchElementException;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -42,7 +41,7 @@ public class CompanyProfileController {
                         new ResponseEntity<>(
                                 new CompanyProfile().data(document.companyProfile),
                                 HttpStatus.OK))
-                .orElse(ResponseEntity.notFound().build());
+                .orElse(ResponseEntity.status(HttpStatus.GONE).build());
     }
 
     /**
@@ -59,11 +58,7 @@ public class CompanyProfileController {
             @Valid @RequestBody CompanyProfile requestBody) {
         logger.info(String.format("Payload successfully received on PATCH endpoint "
                 + "with contextId %s and company number %s", contextId, companyNumber));
-        try {
-            companyProfileService.updateInsolvencyLink(contextId, companyNumber, requestBody);
-            return ResponseEntity.status(HttpStatus.OK).build();
-        } catch (NoSuchElementException noSuchElementException) {
-            return ResponseEntity.notFound().build();
-        }
+        companyProfileService.updateInsolvencyLink(contextId, companyNumber, requestBody);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/exception/ControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/exception/ControllerExceptionHandler.java
@@ -102,6 +102,26 @@ public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     /**
+     * DocumentGoneException exception handler.
+     * Thrown when the requested document could not be found in the DB in place of status code 404.
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
+    @ExceptionHandler(value = {DocumentGoneException.class})
+    public ResponseEntity<Object> handleDocumentGoneException(Exception ex,
+                                                              WebRequest request) {
+        String errMsg = "Resource gone";
+        HashMap<String, Object> data = buildExceptionResponse(errMsg);
+        logger.errorContext(request.getHeader(X_REQUEST_ID_HEADER), errMsg, ex, data);
+
+        return ResponseEntity
+                .status(HttpStatus.GONE)
+                .body(data);
+    }
+
+    /**
      * BadRequestException 400 handler.
      * Thrown when data in RequestBody is not valid.
      *

--- a/src/main/java/uk/gov/companieshouse/company/profile/exception/DocumentGoneException.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/exception/DocumentGoneException.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.company.profile.exception;
+
+public class DocumentGoneException extends RuntimeException {
+
+    public DocumentGoneException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company.profile.api.InsolvencyApiService;
 import uk.gov.companieshouse.company.profile.exception.BadRequestException;
+import uk.gov.companieshouse.company.profile.exception.DocumentGoneException;
 import uk.gov.companieshouse.company.profile.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.company.profile.model.CompanyProfileDocument;
 import uk.gov.companieshouse.company.profile.model.Updated;
@@ -89,11 +90,11 @@ public class CompanyProfileService {
             Optional<CompanyProfileDocument> cpDocumentOptional =
                     companyProfileRepository.findById(companyNumber);
 
-            cpDocumentOptional.orElseThrow(() -> new BadRequestException(
-                    String.format("No company profile with company number %s found",
-                    companyNumber)));
+            var cpDocument = cpDocumentOptional.orElseThrow(() ->
+                    new DocumentGoneException(
+                        String.format("No company profile with company number %s found",
+                                companyNumber)));
 
-            CompanyProfileDocument cpDocument = cpDocumentOptional.get();
             companyProfileRequest.getData().setEtag(GenerateEtagUtil.generateEtag());
 
             cpDocument.setCompanyProfile(companyProfileRequest.getData());

--- a/src/test/java/uk/gov/companieshouse/company/profile/exception/ControllerExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/exception/ControllerExceptionHandlerTest.java
@@ -115,6 +115,7 @@ class ControllerExceptionHandlerTest {
                 Arguments.of(404, "Resource not found", IllegalArgumentException.class),
                 Arguments.of(405, "Method not allowed",
                         HttpRequestMethodNotSupportedException.class),
+                Arguments.of(410, "Resource gone", DocumentGoneException.class),
                 Arguments.of(503, "Service unavailable", ServiceUnavailableException.class),
                 Arguments.of(500, "Unexpected exception", RuntimeException.class),
                 Arguments.of(500, "Unexpected exception", NoSuchMethodException.class)


### PR DESCRIPTION
- Return a 410 (Gone) response code if the insolvency document is not found in the database for a given company number across all endpoints doing a get call to the db.

Resolves:

[DSND-929](https://companieshouse.atlassian.net/browse/DSND-929)