### PR TITLE
DSND-1264 Implement delete exemptions link endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.company.profile.controller;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -86,11 +85,11 @@ public class CompanyProfileController {
      * @param companyNumber The number of the company
      * @return no response
      */
-    @DeleteMapping("/company/{company_number}/links/exemptions")
+    @PatchMapping("/company/{company_number}/links/exemptions/delete")
     public ResponseEntity<Void> deleteExemptionsLink(
             @RequestHeader("x-request-id") String contextId,
             @PathVariable("company_number") String companyNumber) {
-        logger.info(String.format("Request received on DELETE endpoint "
+        logger.info(String.format("Payload successfully received on PATCH endpoint "
                 + "with contextId %s and company number %s", contextId, companyNumber));
         companyProfileService.deleteExemptionsLink(contextId, companyNumber);
         return ResponseEntity.status(HttpStatus.OK).build();

--- a/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.company.profile.controller;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -76,6 +77,22 @@ public class CompanyProfileController {
         logger.info(String.format("Payload successfully received on PATCH endpoint "
                 + "with contextId %s and company number %s", contextId, companyNumber));
         companyProfileService.addExemptionsLink(contextId, companyNumber);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * Delete a company exemptions link on a company profile for the given company number.
+     *
+     * @param companyNumber The number of the company
+     * @return no response
+     */
+    @DeleteMapping("/company/{company_number}/links/exemptions")
+    public ResponseEntity<Void> deleteExemptionsLink(
+            @RequestHeader("x-request-id") String contextId,
+            @PathVariable("company_number") String companyNumber) {
+        logger.info(String.format("Request received on DELETE endpoint "
+                + "with contextId %s and company number %s", contextId, companyNumber));
+        companyProfileService.deleteExemptionsLink(contextId, companyNumber);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -184,6 +184,52 @@ public class CompanyProfileService {
         }
     }
 
+    /**
+     * Delete an exemptions link for a company profile and call chs-kafka-api
+     * to notify a resource has been changed.
+     *
+     * @param contextId Request ID from request header "x-request-id
+     * @param companyNumber The number of the company to update
+     */
+    public void deleteExemptionsLink(String contextId, String companyNumber) {
+        try {
+            CompanyProfileDocument document = companyProfileRepository.findById(companyNumber)
+                    .orElseThrow(() -> new DocumentNotFoundException(
+                            String.format("No company profile with company number %s found",
+                                    companyNumber)));
+
+            if (StringUtils.isBlank(document.getCompanyProfile().getLinks().getExemptions())) {
+                logger.error("Exemptions link for company profile already does not exist");
+                throw new ResourceStateConflictException("Resource state conflict; "
+                        + "exemptions link already does not exist");
+            }
+
+            companyProfileApiService.invokeChsKafkaApi(contextId, companyNumber);
+            logger.info(String.format("chs-kafka-api DELETED invoked successfully for context "
+                    + "id: %s and company number: %s", contextId, companyNumber));
+
+            Update update = new Update();
+            update.unset("data.links.exemptions");
+            update.set("data.etag", GenerateEtagUtil.generateEtag());
+            update.set("updated", new Updated()
+                    .setAt(LocalDateTime.now())
+                    .setType("exemption_delta")
+                    .setBy(contextId));
+            Query query = new Query(Criteria.where("_id").is(companyNumber));
+
+            mongoTemplate.updateFirst(query, update, CompanyProfileDocument.class);
+            logger.info(String.format("Company exemptions link deleted in Company Profile "
+                            + "with context id: %s and company number: %s",
+                    contextId, companyNumber));
+        } catch (IllegalArgumentException | ApiErrorResponseException exception) {
+            logger.error("Error calling chs-kafka-api");
+            throw new ServiceUnavailableException(exception.getMessage());
+        } catch (DataAccessException exception) {
+            logger.error("Error accessing MongoDB");
+            throw new ServiceUnavailableException(exception.getMessage());
+        }
+    }
+
     private void updateSpecificFields(CompanyProfileDocument companyProfileDocument) {
         Update update = new Update();
         setUpdateIfNotNull(update, "data.etag",

--- a/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -53,6 +52,8 @@ class CompanyProfileControllerTest {
     private static final String MOCK_COMPANY_NUMBER = "6146287";
     private static final String COMPANY_URL = String.format("/company/%s/links", MOCK_COMPANY_NUMBER);
     private static final String EXEMPTIONS_LINK_URL = String.format("/company/%s/links/exemptions", MOCK_COMPANY_NUMBER);
+
+    private static final String DELETE_EXEMPTIONS_LINK_URL = String.format("/company/%s/links/exemptions/delete", MOCK_COMPANY_NUMBER);
 
     @MockBean
     private Logger logger;
@@ -284,7 +285,7 @@ class CompanyProfileControllerTest {
     void deleteExemptionsLink() throws Exception {
         doNothing().when(companyProfileService).deleteExemptionsLink(anyString(), anyString());
 
-        mockMvc.perform(delete(EXEMPTIONS_LINK_URL)
+        mockMvc.perform(patch(DELETE_EXEMPTIONS_LINK_URL)
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
                         .contentType(APPLICATION_JSON)
@@ -299,7 +300,7 @@ class CompanyProfileControllerTest {
         doThrow(new DocumentNotFoundException("Not Found"))
                 .when(companyProfileService).deleteExemptionsLink(anyString(), anyString());
 
-        mockMvc.perform(delete(EXEMPTIONS_LINK_URL)
+        mockMvc.perform(patch(DELETE_EXEMPTIONS_LINK_URL)
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
                         .contentType(APPLICATION_JSON)
@@ -314,7 +315,7 @@ class CompanyProfileControllerTest {
         doThrow(new ResourceStateConflictException("Conflict in resource state"))
                 .when(companyProfileService).deleteExemptionsLink(anyString(), anyString());
 
-        mockMvc.perform(delete(EXEMPTIONS_LINK_URL)
+        mockMvc.perform(patch(DELETE_EXEMPTIONS_LINK_URL)
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
@@ -329,7 +330,7 @@ class CompanyProfileControllerTest {
         doThrow(new ServiceUnavailableException("Service unavailable - connection issue"))
                 .when(companyProfileService).deleteExemptionsLink(anyString(), anyString());
 
-        mockMvc.perform(delete(EXEMPTIONS_LINK_URL)
+        mockMvc.perform(patch(DELETE_EXEMPTIONS_LINK_URL)
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
@@ -344,7 +345,7 @@ class CompanyProfileControllerTest {
         doThrow(new RuntimeException())
                 .when(companyProfileService).deleteExemptionsLink(anyString(), anyString());
 
-        mockMvc.perform(delete(EXEMPTIONS_LINK_URL)
+        mockMvc.perform(patch(DELETE_EXEMPTIONS_LINK_URL)
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")

--- a/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
@@ -9,7 +9,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
@@ -9,8 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -276,5 +275,79 @@ class CompanyProfileControllerTest {
                         .header("ERIC-Identity-Type", "key"))
                 .andExpect(status().isInternalServerError());
         verify(companyProfileService).addExemptionsLink("123456", MOCK_COMPANY_NUMBER);
+    }
+
+    @Test
+    @DisplayName("Delete company exemptions link")
+    void deleteExemptionsLink() throws Exception {
+        doNothing().when(companyProfileService).deleteExemptionsLink(anyString(), anyString());
+
+        mockMvc.perform(delete(EXEMPTIONS_LINK_URL)
+                        .header("ERIC-Identity", "SOME_IDENTITY")
+                        .header("ERIC-Identity-Type", "key")
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "123456"))
+                .andExpect(status().isOk());
+        verify(companyProfileService).deleteExemptionsLink("123456", MOCK_COMPANY_NUMBER);
+    }
+
+    @Test
+    @DisplayName("Delete exemptions link request returns 404 not found when document not found exception is thrown")
+    void deleteExemptionsLinkNotFound() throws Exception {
+        doThrow(new DocumentNotFoundException("Not Found"))
+                .when(companyProfileService).deleteExemptionsLink(anyString(), anyString());
+
+        mockMvc.perform(delete(EXEMPTIONS_LINK_URL)
+                        .header("ERIC-Identity", "SOME_IDENTITY")
+                        .header("ERIC-Identity-Type", "key")
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "123456"))
+                .andExpect(status().isNotFound());
+        verify(companyProfileService).deleteExemptionsLink("123456", MOCK_COMPANY_NUMBER);
+    }
+
+    @Test
+    @DisplayName("Delete exemptions link request returns 409 not found when resource state conflict exception is thrown")
+    void deleteExemptionsLinkConflict() throws Exception {
+        doThrow(new ResourceStateConflictException("Conflict in resource state"))
+                .when(companyProfileService).deleteExemptionsLink(anyString(), anyString());
+
+        mockMvc.perform(delete(EXEMPTIONS_LINK_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "123456")
+                        .header("ERIC-Identity", "SOME_IDENTITY")
+                        .header("ERIC-Identity-Type", "key"))
+                .andExpect(status().isConflict());
+        verify(companyProfileService).deleteExemptionsLink("123456", MOCK_COMPANY_NUMBER);
+    }
+
+    @Test()
+    @DisplayName("Delete exemptions link request returns 503 service unavailable when a service unavailable exception is thrown")
+    void deleteExemptionsLinkServiceUnavailable() throws Exception {
+        doThrow(new ServiceUnavailableException("Service unavailable - connection issue"))
+                .when(companyProfileService).deleteExemptionsLink(anyString(), anyString());
+
+        mockMvc.perform(delete(EXEMPTIONS_LINK_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "123456")
+                        .header("ERIC-Identity", "SOME_IDENTITY")
+                        .header("ERIC-Identity-Type", "key"))
+                .andExpect(status().isServiceUnavailable());
+        verify(companyProfileService).deleteExemptionsLink("123456", MOCK_COMPANY_NUMBER);
+    }
+
+    @Test()
+    @DisplayName("Delete exemptions link request returns 500 internal server error when a runtime exception is thrown")
+    void deleteExemptionsLinkInternalServerError() throws Exception {
+        doThrow(new RuntimeException())
+                .when(companyProfileService).deleteExemptionsLink(anyString(), anyString());
+
+        mockMvc.perform(delete(EXEMPTIONS_LINK_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", "123456")
+                        .header("ERIC-Identity", "SOME_IDENTITY")
+                        .header("ERIC-Identity-Type", "key"))
+                .andExpect(status().isInternalServerError());
+        verify(companyProfileService).deleteExemptionsLink("123456", MOCK_COMPANY_NUMBER);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -43,14 +43,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyProfileServiceTest {
     private static final String MOCK_COMPANY_NUMBER = "6146287";
     private static final String MOCK_CONTEXT_ID = "123456";
-    private static final String MOCK_EXEMPTIONS = "/company/6146287/exemptions";
 
     @Mock
     CompanyProfileRepository companyProfileRepository;


### PR DESCRIPTION
* Calls to the new endpoint delete an exemptions link in a company profile for a specified company number.
* If the company profile does not have an exemptions link then HTTP 409 conflict is returned.
* HTTP 503 service unavailable is returned when requests to either MongoDB or chs-kaka-api fail.

[DSND-1264](https://companieshouse.atlassian.net/browse/DSND-1264)