### PR TITLE
Reorder calls to chs-kafka-api and repository

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company/profile/api/CompanyProfileApiService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/api/CompanyProfileApiService.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.company.profile.api;
 import java.time.OffsetDateTime;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.company.profile.service;
 
-import com.mongodb.client.result.UpdateResult;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -158,10 +157,6 @@ public class CompanyProfileService {
                         + "exemptions link already exists");
             }
 
-            companyProfileApiService.invokeChsKafkaApi(contextId, companyNumber);
-            logger.info(String.format("chs-kafka-api CHANGED invoked successfully for context "
-                    + "id: %s and company number: %s", contextId, companyNumber));
-
             Query query = new Query(Criteria.where("_id").is(companyNumber));
             Update update = Update.update("data.links.exemptions",
                     String.format("/company/%s/exemptions", companyNumber));
@@ -175,6 +170,10 @@ public class CompanyProfileService {
             logger.info(String.format("Company exemptions link inserted in Company Profile "
                             + "with context id: %s and company number: %s",
                     contextId, companyNumber));
+
+            companyProfileApiService.invokeChsKafkaApi(contextId, companyNumber);
+            logger.info(String.format("chs-kafka-api CHANGED invoked successfully for context "
+                    + "id: %s and company number: %s", contextId, companyNumber));
         } catch (IllegalArgumentException | ApiErrorResponseException exception) {
             logger.error("Error calling chs-kafka-api");
             throw new ServiceUnavailableException(exception.getMessage());
@@ -204,10 +203,6 @@ public class CompanyProfileService {
                         + "exemptions link already does not exist");
             }
 
-            companyProfileApiService.invokeChsKafkaApi(contextId, companyNumber);
-            logger.info(String.format("chs-kafka-api DELETED invoked successfully for context "
-                    + "id: %s and company number: %s", contextId, companyNumber));
-
             Update update = new Update();
             update.unset("data.links.exemptions");
             update.set("data.etag", GenerateEtagUtil.generateEtag());
@@ -221,6 +216,10 @@ public class CompanyProfileService {
             logger.info(String.format("Company exemptions link deleted in Company Profile "
                             + "with context id: %s and company number: %s",
                     contextId, companyNumber));
+
+            companyProfileApiService.invokeChsKafkaApi(contextId, companyNumber);
+            logger.info(String.format("chs-kafka-api DELETED invoked successfully for context "
+                    + "id: %s and company number: %s", contextId, companyNumber));
         } catch (IllegalArgumentException | ApiErrorResponseException exception) {
             logger.error("Error calling chs-kafka-api");
             throw new ServiceUnavailableException(exception.getMessage());

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -279,7 +279,6 @@ class CompanyProfileServiceTest {
         assertThrows(ServiceUnavailableException.class, executable);
         verify(companyProfileRepository).findById(MOCK_COMPANY_NUMBER);
         verify(companyProfileApiService).invokeChsKafkaApi(MOCK_CONTEXT_ID, MOCK_COMPANY_NUMBER);
-        verifyNoInteractions(mongoTemplate);
     }
 
     @Test
@@ -313,7 +312,7 @@ class CompanyProfileServiceTest {
         // then
         assertThrows(ServiceUnavailableException.class, executable);
         verify(companyProfileRepository).findById(MOCK_COMPANY_NUMBER);
-        verify(companyProfileApiService).invokeChsKafkaApi(MOCK_CONTEXT_ID, MOCK_COMPANY_NUMBER);
+        verifyNoInteractions(companyProfileApiService);
     }
 
     @Test
@@ -386,7 +385,6 @@ class CompanyProfileServiceTest {
         assertThrows(ServiceUnavailableException.class, executable);
         verify(companyProfileRepository).findById(MOCK_COMPANY_NUMBER);
         verify(companyProfileApiService).invokeChsKafkaApi(MOCK_CONTEXT_ID, MOCK_COMPANY_NUMBER);
-        verifyNoInteractions(mongoTemplate);
     }
 
     @Test
@@ -421,7 +419,7 @@ class CompanyProfileServiceTest {
         // then
         assertThrows(ServiceUnavailableException.class, executable);
         verify(companyProfileRepository).findById(MOCK_COMPANY_NUMBER);
-        verify(companyProfileApiService).invokeChsKafkaApi(MOCK_CONTEXT_ID, MOCK_COMPANY_NUMBER);
+        verifyNoInteractions(companyProfileApiService);
     }
 
     private CompanyProfile mockCompanyProfileWithoutInsolvency() {


### PR DESCRIPTION
* Save or delete a record in the database before calling chs-kafka-api to ensure resource-change-publisher
doesn't get an outdated record.