### PR TITLE
DSND-1542: API does not check for internal user privileges

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
                 <configuration>
                     <mainClass>${main.class}</mainClass>
                 </configuration>

--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerITest.java
@@ -18,7 +18,9 @@ import uk.gov.companieshouse.company.profile.model.Updated;
 import uk.gov.companieshouse.company.profile.service.CompanyProfileService;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class CompanyProfileControllerITest {
@@ -112,6 +114,7 @@ class CompanyProfileControllerITest {
         headers.set("x-request-id", "123456");
         headers.add("ERIC-Identity" , "SOME_IDENTITY");
         headers.add("ERIC-Identity-Type", "key");
+        headers.add("ERIC-Authorised-Key-Privileges", "internal-app");
 
         HttpEntity<CompanyProfile> httpEntity = new HttpEntity<>(mockCompanyProfile, headers);
         ResponseEntity<Void> responseEntity = restTemplate.exchange(
@@ -159,6 +162,7 @@ class CompanyProfileControllerITest {
         headers.set("x-request-id", "123456");
         headers.add("ERIC-Identity" , "SOME_IDENTITY");
         headers.add("ERIC-Identity-Type", "key");
+        headers.add("ERIC-Authorised-Key-Privileges", "internal-app");
 
         HttpEntity<CompanyProfile> httpEntity = new HttpEntity<>(mockCompanyProfile, headers);
         ResponseEntity<Void> responseEntity = restTemplate.exchange(

--- a/src/itest/java/uk/gov/companieshouse/company/profile/steps/CompanyProfileSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/steps/CompanyProfileSteps.java
@@ -90,6 +90,7 @@ public class CompanyProfileSteps {
         headers.set("x-request-id", "5234234234");
         headers.set("ERIC-Identity" , "SOME_IDENTITY");
         headers.set("ERIC-Identity-Type", "key");
+        headers.add("ERIC-Authorised-Key-Privileges", "internal-app");
 
         HttpEntity<CompanyProfile> request = new HttpEntity<>(companyProfile, headers);
         String uri = "/company/{company_number}/links";
@@ -114,6 +115,7 @@ public class CompanyProfileSteps {
         headers.set("x-request-id", "5234234234");
         headers.set("ERIC-Identity" , "SOME_IDENTITY");
         headers.set("ERIC-Identity-Type", "key");
+        headers.add("ERIC-Authorised-Key-Privileges", "internal-app");
 
         HttpEntity<CompanyProfile> request = new HttpEntity<>(companyProfile, headers);
         String uri = "/company/{company_number}/links";
@@ -152,6 +154,7 @@ public class CompanyProfileSteps {
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         headers.set("ERIC-Identity" , "SOME_IDENTITY");
         headers.set("ERIC-Identity-Type", "key");
+        headers.add("ERIC-Authorised-Key-Privileges", "internal-app");
 
         this.contextId = "5234234234";
         headers.set("x-request-id", this.contextId);
@@ -265,7 +268,7 @@ public class CompanyProfileSteps {
         Optional<CompanyProfileDocument> actual = companyProfileRepository.findById(this.companyNumber);
         LocalDateTime at = actual.get().getUpdated().getAt();
 
-        /**
+        /*
          * Initially the updated year is set to 2021, if the call to db is triggered then the year is set to 2022.
          * Since the save operation is not invoked the updated date remains as initial year.
          */

--- a/src/itest/java/uk/gov/companieshouse/company/profile/steps/ExemptionsLinkSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/steps/ExemptionsLinkSteps.java
@@ -60,6 +60,7 @@ public class ExemptionsLinkSteps {
         headers.set("x-request-id", this.contextId);
         headers.set("ERIC-Identity", "TEST-IDENTITY");
         headers.set("ERIC-Identity-Type", "KEY");
+        headers.add("ERIC-Authorised-Key-Privileges", "internal-app");
 
         HttpEntity<String> request = new HttpEntity<String>(null, headers);
         ResponseEntity<Void> response = restTemplate.exchange(
@@ -110,6 +111,7 @@ public class ExemptionsLinkSteps {
         headers.set("x-request-id", this.contextId);
         headers.set("ERIC-Identity", "TEST-IDENTITY");
         headers.set("ERIC-Identity-Type", "KEY");
+        headers.add("ERIC-Authorised-Key-Privileges", "internal-app");
 
         HttpEntity<String> request = new HttpEntity<String>(null, headers);
         ResponseEntity<Void> response = restTemplate.exchange(
@@ -132,5 +134,4 @@ public class ExemptionsLinkSteps {
                 DELETE_EXEMPTIONS_LINK_ENDPOINT, HttpMethod.PATCH, request, Void.class, companyNumber);
         CucumberContext.CONTEXT.set("statusCode", response.getStatusCode().value());
     }
-
 }

--- a/src/itest/java/uk/gov/companieshouse/company/profile/steps/OfficersLinkSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/steps/OfficersLinkSteps.java
@@ -68,6 +68,7 @@ public class OfficersLinkSteps {
         headers.set("x-request-id", this.contextId);
         headers.set("ERIC-Identity", "TEST-IDENTITY");
         headers.set("ERIC-Identity-Type", "KEY");
+        headers.add("ERIC-Authorised-Key-Privileges", "internal-app");
 
         HttpEntity<String> request = new HttpEntity<String>(null, headers);
         ResponseEntity<Void> response = restTemplate.exchange(
@@ -86,6 +87,7 @@ public class OfficersLinkSteps {
         headers.set("x-request-id", this.contextId);
         headers.set("ERIC-Identity", "TEST-IDENTITY");
         headers.set("ERIC-Identity-Type", "KEY");
+        headers.add("ERIC-Authorised-Key-Privileges", "internal-app");
 
         HttpEntity<String> request = new HttpEntity<String>(null, headers);
         ResponseEntity<Void> response = restTemplate.exchange(

--- a/src/main/java/uk/gov/companieshouse/company/profile/auth/EricTokenAuthenticationFilter.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/auth/EricTokenAuthenticationFilter.java
@@ -1,12 +1,14 @@
 package uk.gov.companieshouse.company.profile.auth;
 
 import java.io.IOException;
+import java.util.Optional;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -25,22 +27,42 @@ public class EricTokenAuthenticationFilter extends OncePerRequestFilter {
         String ericIdentity = request.getHeader("ERIC-Identity");
 
         if (StringUtils.isBlank(ericIdentity)) {
-            logger.error("Unauthorised request received without eric identity");
+            logger.error("Request received without eric identity");
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
 
         String ericIdentityType = request.getHeader("ERIC-Identity-Type");
 
-        if (StringUtils.isBlank(ericIdentityType)
-                || !(ericIdentityType.equalsIgnoreCase("key")
-                || (ericIdentityType.equalsIgnoreCase("oauth2")))) {
-            logger.error("Unauthorised request received without eric identity type");
+        if (!("key".equalsIgnoreCase(ericIdentityType)
+                || ("oauth2".equalsIgnoreCase(ericIdentityType)))) {
+            logger.error("Request received without correct eric identity type");
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        if (!isKeyAuthorised(request, ericIdentityType)) {
+            logger.info("Supplied key does not have sufficient privilege for the action");
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
 
         filterChain.doFilter(request, response);
     }
 
+    private boolean isKeyAuthorised(HttpServletRequest request, String ericIdentityType) {
+        String[] privileges = getApiKeyPrivileges(request);
+
+        return request.getMethod().equals("GET")
+                || (ericIdentityType.equalsIgnoreCase("Key")
+                && ArrayUtils.contains(privileges, "internal-app"));
+    }
+
+    private String[] getApiKeyPrivileges(HttpServletRequest request) {
+        String commaSeparatedPrivilegeString = request.getHeader("ERIC-Authorised-Key-Privileges");
+
+        return Optional.ofNullable(commaSeparatedPrivilegeString)
+                .map(s -> s.split(","))
+                .orElse(new String[]{});
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/company/profile/auth/EricTokenAuthenticationFilterTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/auth/EricTokenAuthenticationFilterTest.java
@@ -2,8 +2,9 @@ package uk.gov.companieshouse.company.profile.auth;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.logging.Logger;
 
 import javax.servlet.FilterChain;
@@ -16,7 +17,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class EricTokenAuthenticationFilterTest {
 
     @Mock

--- a/src/test/java/uk/gov/companieshouse/company/profile/auth/EricTokenAuthenticationFilterTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/auth/EricTokenAuthenticationFilterTest.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,27 +32,153 @@ public class EricTokenAuthenticationFilterTest {
     FilterChain filterChain;
 
     @Test
-    @DisplayName("EricTokenAuthenticationFilter doFilterInternal Test successfully calling filterchain method")
+    @DisplayName("OAUTH2 GET request passes filter")
     void doFilterInternal() throws ServletException, IOException {
         EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
 
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
         when(request.getHeader("ERIC-Identity-Type")).thenReturn("OAUTH2");
+        when(request.getMethod()).thenReturn("GET");
 
         ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
-        verify(filterChain, times(1)).doFilter(request, response);
+        verify(filterChain).doFilter(request, response);
     }
 
     @Test
-    @DisplayName("EricTokenAuthenticationFilter doFilterInternal Test not filterchain method when not passing proper Eric headers")
-    void doFilterInternalNoCallToFilterChain() throws ServletException, IOException {
+    @DisplayName("KEY type GET request passes filter")
+    void doFilterInternalKey() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
+        when(request.getMethod()).thenReturn("GET");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("KEY type GET request with internal app privileges passes filter")
+    void doFilterInternalKeyAndInternalApp() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
+        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("internal-app");
+        when(request.getMethod()).thenReturn("GET");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("KEY type PUT request with internal app privileges passes filter")
+    void doFilterInternalMethodPutTypeKeyAndInternalApp() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
+        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("internal-app");
+        when(request.getMethod()).thenReturn("PUT");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Request with no identity fails ")
+    void doFilterInternalNoIdentity() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Request with no identity type fails ")
+    void doFilterInternalNoIdentityType() throws ServletException, IOException {
         EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
 
         when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
 
         ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
-        verify(filterChain, times(0)).doFilter(request, response);
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Request with wrong identity type fails ")
+    void doFilterInternalWrongIdentityType() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("identityType");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("PUT Request with OAUTH2 type fails")
+    void doFilterInternalOauth2WrongMethod() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("OAUTH2");
+        when(request.getMethod()).thenReturn("PUT");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("PUT Request with OAUTH2 type and internal app privilege fails")
+    void doFilterInternalOauth2WrongMethodWithPrivilege() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("OAUTH2");
+        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("internal-app");
+        when(request.getMethod()).thenReturn("PUT");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("PUT Request with KEY type with no privileges fails")
+    void doFilterInternalKeyNoPrivileges() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
+        when(request.getMethod()).thenReturn("PUT");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("PUT Request with KEY type with wrong privileges fails")
+    void doFilterInternalKeyWrongPrivileges() throws ServletException, IOException {
+        EricTokenAuthenticationFilter ericTokenAuthenticationFilter = new EricTokenAuthenticationFilter(logger);
+
+        when(request.getHeader("ERIC-Identity")).thenReturn("SOME-IDENTITY");
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn("KEY");
+        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("privilege");
+        when(request.getMethod()).thenReturn("PUT");
+
+        ericTokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
@@ -159,7 +159,9 @@ class CompanyProfileControllerTest {
                 .header("ERIC-Identity-Type", "key")
                 .contentType(APPLICATION_JSON)
                 .header("x-request-id", "123456")
-                .content(gson.toJson(request))).andExpect(status().isOk());
+                .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .content(gson.toJson(request)))
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -173,6 +175,7 @@ class CompanyProfileControllerTest {
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app")
                         .content(gson.toJson(new CompanyProfile())))
                 .andExpect(status().isNotFound());
     }
@@ -188,6 +191,7 @@ class CompanyProfileControllerTest {
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app")
                         .content(gson.toJson(new CompanyProfile())))
                 .andExpect(status().isBadRequest());
     }
@@ -203,7 +207,8 @@ class CompanyProfileControllerTest {
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
-                        .content(gson.toJson(new CompanyProfile())))
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .content(gson.toJson(new CompanyProfile())))
                 .andExpect(status().isServiceUnavailable());
     }
 
@@ -217,7 +222,8 @@ class CompanyProfileControllerTest {
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
-                        .content(gson.toJson(new CompanyProfile())))
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .content(gson.toJson(new CompanyProfile())))
                 .andExpect(status().isInternalServerError());
     }
 
@@ -232,6 +238,7 @@ class CompanyProfileControllerTest {
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
                         .contentType(APPLICATION_JSON)
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app")
                         .header("x-request-id", "123456"))
                 .andExpect(status().isOk());
         verify(companyProfileService).addExemptionsLink(exemptionsLinkRequest);
@@ -249,7 +256,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isNotFound());
         verify(companyProfileService).addExemptionsLink(exemptionsLinkRequest);
     }
@@ -266,7 +274,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isConflict());
         verify(companyProfileService).addExemptionsLink(exemptionsLinkRequest);
     }
@@ -283,7 +292,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isServiceUnavailable());
         verify(companyProfileService).addExemptionsLink(exemptionsLinkRequest);
     }
@@ -299,7 +309,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isInternalServerError());
         verify(companyProfileService).addExemptionsLink(exemptionsLinkRequest);
     }
@@ -315,7 +326,8 @@ class CompanyProfileControllerTest {
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
                         .contentType(APPLICATION_JSON)
-                        .header("x-request-id", "123456"))
+                        .header("x-request-id", "123456")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isOk());
         verify(companyProfileService).deleteExemptionsLink(exemptionsLinkRequest);
     }
@@ -332,7 +344,8 @@ class CompanyProfileControllerTest {
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
                         .contentType(APPLICATION_JSON)
-                        .header("x-request-id", "123456"))
+                        .header("x-request-id", "123456")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isNotFound());
         verify(companyProfileService).deleteExemptionsLink(exemptionsLinkRequest);
     }
@@ -349,7 +362,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isConflict());
         verify(companyProfileService).deleteExemptionsLink(exemptionsLinkRequest);
     }
@@ -366,7 +380,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isServiceUnavailable());
         verify(companyProfileService).deleteExemptionsLink(exemptionsLinkRequest);
     }
@@ -383,7 +398,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isInternalServerError());
         verify(companyProfileService).deleteExemptionsLink(exemptionsLinkRequest);
     }
@@ -399,7 +415,8 @@ class CompanyProfileControllerTest {
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
                         .contentType(APPLICATION_JSON)
-                        .header("x-request-id", "123456"))
+                        .header("x-request-id", "123456")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isOk());
         verify(companyProfileService).addOfficersLink(officersLinkRequest);
     }
@@ -416,8 +433,9 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
-                .andExpect(status().isNotFound());
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app")
+)                .andExpect(status().isNotFound());
         verify(companyProfileService).addOfficersLink(officersLinkRequest);
     }
 
@@ -433,7 +451,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isConflict());
         verify(companyProfileService).addOfficersLink(officersLinkRequest);
     }
@@ -450,7 +469,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isServiceUnavailable());
         verify(companyProfileService).addOfficersLink(officersLinkRequest);
     }
@@ -466,7 +486,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isInternalServerError());
         verify(companyProfileService).addOfficersLink(officersLinkRequest);
     }
@@ -482,7 +503,8 @@ class CompanyProfileControllerTest {
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
                         .contentType(APPLICATION_JSON)
-                        .header("x-request-id", "123456"))
+                        .header("x-request-id", "123456")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isOk());
         verify(companyProfileService).deleteOfficersLink(officersLinkRequest);
     }
@@ -499,7 +521,8 @@ class CompanyProfileControllerTest {
                         .header("ERIC-Identity", "SOME_IDENTITY")
                         .header("ERIC-Identity-Type", "key")
                         .contentType(APPLICATION_JSON)
-                        .header("x-request-id", "123456"))
+                        .header("x-request-id", "123456")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isNotFound());
         verify(companyProfileService).deleteOfficersLink(officersLinkRequest);
     }
@@ -516,7 +539,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isConflict());
         verify(companyProfileService).deleteOfficersLink(officersLinkRequest);
     }
@@ -533,7 +557,8 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isServiceUnavailable());
         verify(companyProfileService).deleteOfficersLink(officersLinkRequest);
     }
@@ -550,9 +575,9 @@ class CompanyProfileControllerTest {
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", "123456")
                         .header("ERIC-Identity", "SOME_IDENTITY")
-                        .header("ERIC-Identity-Type", "key"))
+                        .header("ERIC-Identity-Type", "key")
+                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
                 .andExpect(status().isInternalServerError());
         verify(companyProfileService).deleteOfficersLink(officersLinkRequest);
     }
-
 }


### PR DESCRIPTION
* Authorise OAUTH2 requests only if they are GET requests
* Authorise KEY requests only if they have internal app privileges

[DSND-1542](https://companieshouse.atlassian.net/browse/DSND-1542)

[DSND-1542]: https://companieshouse.atlassian.net/browse/DSND-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ