### PR TITLE
SuperSecureManagingOfficerCount should not be returned on a Get so se…

### DIFF
--- a/src/itest/resources/json/input/00006402.json
+++ b/src/itest/resources/json/input/00006402.json
@@ -51,6 +51,7 @@
     "sic_codes": [
       "72110"
     ],
-    "type": "ltd"
+    "type": "ltd",
+    "super_secure_managing_officer_count": "1"
   }
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -372,6 +372,12 @@ public class CompanyProfileService {
         CompanyProfileDocument companyProfileDocument = getCompanyProfileDocument(companyNumber);
         companyProfileDocument = determineCanFile(companyProfileDocument);
         companyProfileDocument = determineOverdue(companyProfileDocument);
+
+        //SuperSecureManagingOfficerCount should not be returned on a Get request
+        if (companyProfileDocument.getCompanyProfile() != null) {
+            companyProfileDocument.getCompanyProfile().setSuperSecureManagingOfficerCount(null);
+        }
+
         return companyProfileDocument.getCompanyProfile();
     }
 


### PR DESCRIPTION
…tting it to null on the return value. Added the field in the Get itest, which then failed before having the change to set it to null, and now passes again. DSND-2032