### PR TITLE
DSND-2381 Remove /company and /company-detail endpoints from routes.yaml

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -4,5 +4,3 @@ weight: 990
 routes:
    1: ^/company-profile-api/healthcheck
    2: ^/company/(.*)/links.*
-   3: ^/company/(.*)/company-detail
-   4: ^/company/(.){8}$


### PR DESCRIPTION
* This will allow for subdelta deployment to happen independently

https://companieshouse.atlassian.net/browse/DSND-2381