### PR TITLE
DSND-2665: Remove routes for filing history release

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -4,6 +4,3 @@ weight: 990
 routes:
    1: ^/company-profile-api/healthcheck
    2: ^/company/(.*)/links.*
-   3: ^/company/(.*)/company-detail
-   4: ^/company/(.*)/uk-establishments
-   5: ^/company/(.){8}$


### PR DESCRIPTION
* Remove routes which are not required for the release of filing history sub deltas.

[DSND-2665](https://companieshouse.atlassian.net/browse/DSND-2665)

[DSND-2665]: https://companieshouse.atlassian.net/browse/DSND-2665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ