### PR TITLE
Split target groups to keep better count of requests going to links and requests for company profile

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -5,7 +5,7 @@ locals {
   name_prefix_links               = "${local.stack_name}-${var.environment}-links"
   global_prefix                   = "global-${var.environment}"
   service_name                    = "company-profile-api"
-  service_name_links              = "company-profile-api-links"
+  service_name_links              = "links-company-profile-api"
   container_port                  = "8080"
   eric_port                       = "10000"
   docker_repo                     = "company-profile-api"

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -6,10 +6,10 @@ use_set_environment_files = true
 required_cpus = 768
 required_memory = 1536
 
-desired_task_count = 4
-max_task_count = 6
-min_task_count = 3
+desired_task_count = 5
+max_task_count = 8
+min_task_count = 4
 
-desired_task_count_links = 4
-max_task_count_links = 6
-min_task_count_links = 3
+desired_task_count_links = 5
+max_task_count_links = 8
+min_task_count_links = 4


### PR DESCRIPTION
Target group name built through

name        = endswith(substr("${var.environment}-${each.key}-${var.service_name}", 0, 32), "-") ? substr("${var.environment}-${each.key}-${var.service_name}", 0, 31) : substr("${var.environment}-${each.key}-${var.service_name}", 0, 32)

This has created one shared target group between links and regular company profile api instances