### PR TITLE
BI-13964: Round published at to seconds

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company/profile/api/CompanyProfileApiService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/api/CompanyProfileApiService.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.company.profile.api;
 
-import java.time.OffsetDateTime;
-
+import java.time.Instant;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
@@ -12,6 +11,7 @@ import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company.profile.logging.DataMapHolder;
+import uk.gov.companieshouse.company.profile.util.DateUtils;
 import uk.gov.companieshouse.logging.Logger;
 
 @Service
@@ -20,6 +20,7 @@ public class CompanyProfileApiService {
     public static final String CHANGED_EVENT_TYPE = "changed";
     public static final String DELETED_EVENT_TYPE = "deleted";
     private static final String CHANGED_RESOURCE_URI = "/private/resource-changed";
+
     private final Logger logger;
     private final ApiClientService apiClientService;
 
@@ -49,8 +50,8 @@ public class CompanyProfileApiService {
     /**
      * Invoke chs-kafka api with delete event.
      *
-     * @param companyNumber company insolvency number
-     * @param contextId context ID
+     * @param companyNumber  company insolvency number
+     * @param contextId      context ID
      * @param companyProfile the company profile being deleted
      * @return response returned from chs-kafka api
      */
@@ -66,7 +67,7 @@ public class CompanyProfileApiService {
     }
 
     private ChangedResource mapChangedResource(String contextId, String companyNumber,
-                                               String eventType, Data companyProfile) {
+            String eventType, Data companyProfile) {
         ChangedResource changedResource = new ChangedResource();
 
         ChangedResourceEvent event = new ChangedResourceEvent();
@@ -74,7 +75,7 @@ public class CompanyProfileApiService {
         if (eventType.equals(DELETED_EVENT_TYPE)) {
             changedResource.setDeletedData(companyProfile);
         }
-        event.publishedAt(String.valueOf(OffsetDateTime.now()));
+        event.publishedAt(DateUtils.publishedAtString(Instant.now()));
 
         changedResource.setResourceUri("/company/" + companyNumber);
         changedResource.event(event);

--- a/src/main/java/uk/gov/companieshouse/company/profile/util/DateUtils.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/util/DateUtils.java
@@ -9,7 +9,9 @@ import java.time.format.DateTimeFormatter;
 
 public final class DateUtils {
 
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS")
+    private static final DateTimeFormatter DELTA_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS")
+            .withZone(UTC);
+    private static final DateTimeFormatter PUBLISHED_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")
             .withZone(UTC);
 
     private DateUtils() {
@@ -18,12 +20,11 @@ public final class DateUtils {
     public static boolean isDeltaStale(final String requestDeltaAt, final LocalDateTime existingDeltaAt) {
         return requestDeltaAt == null ||
                 (existingDeltaAt != null &&
-                        OffsetDateTime.parse(requestDeltaAt, FORMATTER)
+                        OffsetDateTime.parse(requestDeltaAt, DELTA_AT_FORMATTER)
                                 .isBefore(existingDeltaAt.atOffset(UTC)));
     }
 
     public static String publishedAtString(final Instant source) {
-        return source.atOffset(UTC)
-                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss"));
+        return source.atOffset(UTC).format(PUBLISHED_AT_FORMATTER);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/profile/util/DateUtils.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/util/DateUtils.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company.profile.util;
 
 import static java.time.ZoneOffset.UTC;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -19,5 +20,10 @@ public final class DateUtils {
                 (existingDeltaAt != null &&
                         OffsetDateTime.parse(requestDeltaAt, FORMATTER)
                                 .isBefore(existingDeltaAt.atOffset(UTC)));
+    }
+
+    public static String publishedAtString(final Instant source) {
+        return source.atOffset(UTC)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company/profile/util/DateUtilsTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/util/DateUtilsTest.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.company.profile.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class DateUtilsTest {
+
+    @Test
+    void shouldReturnCurrentTimeAsStringWithCorrectFormat() {
+        // given
+        final String expectedTime = "2024-01-01T12:30:15";
+        final Instant now = Instant.from(
+                OffsetDateTime.of(2024, 1, 1, 12, 30, 15, 0, ZoneOffset.UTC));
+
+        // when
+        final String actual = DateUtils.publishedAtString(now);
+
+        // then
+        assertEquals(expectedTime, actual);
+    }
+}


### PR DESCRIPTION
This PR rounds the `published_at` timestamp to the nearest second. The `published_at` timestamp is sent to CHS Kafka API as part of the Change Resource Event.

Tested locally.

[BI-13964](https://companieshouse.atlassian.net/browse/BI-13957)

[BI-13964]: https://companieshouse.atlassian.net/browse/BI-13964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ