### PR TITLE
Update vars

### DIFF
--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -6,10 +6,10 @@ use_set_environment_files = true
 required_cpus = 768
 required_memory = 1536
 
-desired_task_count = 5
-max_task_count = 8
-min_task_count = 4
+desired_task_count = 10
+max_task_count = 14
+min_task_count = 10
 
-desired_task_count_links = 5
-max_task_count_links = 8
-min_task_count_links = 4
+desired_task_count_links = 3
+max_task_count_links = 5
+min_task_count_links = 2


### PR DESCRIPTION
![Screenshot 2024-12-05 at 14 28 18](https://github.com/user-attachments/assets/6cf87321-9e04-4584-bd11-2aa294f153c1)

Based on private and public company-profile-api getting ~10 times the requests of links.

5 instances current = 1300 requests per instance per second
10 instances = 650 requests per instance per second

Note: Believe eric is the rate determining step here. The service health metrics look completely fine but one side container is started with one instance