### PR TITLE
DSND-3110: Add delta at to delete endpoint

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/company/profile/steps/CompanyProfileSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/steps/CompanyProfileSteps.java
@@ -57,6 +57,7 @@ import uk.gov.companieshouse.company.profile.transform.CompanyProfileTransformer
 public class CompanyProfileSteps {
 
     private static final DateTimeFormatter DELTA_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS");
+    private static final String DELTA_AT = "20241229123010123789";
     private String companyNumber;
     private String contextId;
     private ResponseEntity<Data> response;
@@ -383,7 +384,7 @@ public class CompanyProfileSteps {
         headers.set("Content-Type", "application/json");
 
         HttpEntity<?> request = new HttpEntity<>(data, headers);
-        String uri = "/company/{company_number}";
+        String uri = "/company/{company_number}/internal";
         ResponseEntity<Void> response = restTemplate.exchange(uri, HttpMethod.PUT, request, Void.class, companyNumber);
         CucumberContext.CONTEXT.set("statusCode", response.getStatusCode().value());
     }
@@ -395,7 +396,7 @@ public class CompanyProfileSteps {
         HttpHeaders headers = new HttpHeaders();
 
         HttpEntity<?> request = new HttpEntity<>(data, headers);
-        String uri = "/company/{company_number}";
+        String uri = "/company/{company_number}/internal";
         ResponseEntity<Void> response = restTemplate.exchange(uri, HttpMethod.PUT, request, Void.class, companyNumber);
 
         CucumberContext.CONTEXT.set("statusCode", response.getStatusCode().value());
@@ -415,6 +416,7 @@ public class CompanyProfileSteps {
         this.contextId = "5234234234";
         CucumberContext.CONTEXT.set("contextId", this.contextId);
         headers.set("x-request-id", this.contextId);
+        headers.set("X-DELTA-AT", DELTA_AT);
 
         headers.set("ERIC-Identity", "TEST-IDENTITY");
         headers.set("ERIC-Identity-Type", "key");
@@ -425,7 +427,7 @@ public class CompanyProfileSteps {
 
         HttpEntity<String> request = new HttpEntity<>(null, headers);
         ResponseEntity<Void> response = restTemplate.exchange(
-                "/company/{company_number}", HttpMethod.DELETE, request, Void.class, companyNumber);
+                "/company/{company_number}/internal", HttpMethod.DELETE, request, Void.class, companyNumber);
         CucumberContext.CONTEXT.set("statusCode", response.getStatusCode().value());
     }
 
@@ -438,10 +440,11 @@ public class CompanyProfileSteps {
         this.contextId = "5234234234";
         CucumberContext.CONTEXT.set("contextId", this.contextId);
         headers.set("x-request-id", this.contextId);
+        headers.set("X-DELTA-AT", DELTA_AT);
 
         HttpEntity<String> request = new HttpEntity<String>(null, headers);
         ResponseEntity<Void> response = restTemplate.exchange(
-                "/company/{company_number}/", HttpMethod.DELETE, request, Void.class, companyNumber);
+                "/company/{company_number}/internal", HttpMethod.DELETE, request, Void.class, companyNumber);
         CucumberContext.CONTEXT.set("statusCode", response.getStatusCode().value());
     }
 

--- a/src/itest/java/uk/gov/companieshouse/company/profile/steps/CompanyProfileSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/steps/CompanyProfileSteps.java
@@ -448,6 +448,54 @@ public class CompanyProfileSteps {
         CucumberContext.CONTEXT.set("statusCode", response.getStatusCode().value());
     }
 
+    @When("a DELETE request is sent to the company profile endpoint for {string} with stale delta")
+    public void a_DELETE_request_is_sent_to_the_company_profile_endpoint_for_with_stale_delta(String companyNumber) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+        this.contextId = "5234234234";
+        CucumberContext.CONTEXT.set("contextId", this.contextId);
+        headers.set("x-request-id", this.contextId);
+        headers.set("X-DELTA-AT", "20000815110718375628");
+
+        headers.set("ERIC-Identity", "TEST-IDENTITY");
+        headers.set("ERIC-Identity-Type", "key");
+        headers.set("ERIC-Authorised-Key-Roles", "*");
+        headers.add("api-key", "g9yZIA81Zo9J46Kzp3JPbfld6kOqxR47EAYqXbRV");
+        headers.add("ERIC-Authorised-Key-Privileges", "internal-app");
+        headers.set("Content-Type", "application/json");
+
+        HttpEntity<String> request = new HttpEntity<String>(null, headers);
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "/company/{company_number}/internal", HttpMethod.DELETE, request, Void.class, companyNumber);
+        CucumberContext.CONTEXT.set("statusCode", response.getStatusCode().value());
+    }
+
+    @When("a DELETE request is sent to the company profile endpoint for {string} with blank delta at")
+    public void a_DELETE_request_is_sent_to_the_company_profile_endpoint_for_with_blank_delta_at(String companyNumber) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+        this.contextId = "5234234234";
+        CucumberContext.CONTEXT.set("contextId", this.contextId);
+        headers.set("x-request-id", this.contextId);
+        headers.set("X-DELTA-AT", "");
+
+        headers.set("ERIC-Identity", "TEST-IDENTITY");
+        headers.set("ERIC-Identity-Type", "key");
+        headers.set("ERIC-Authorised-Key-Roles", "*");
+        headers.add("api-key", "g9yZIA81Zo9J46Kzp3JPbfld6kOqxR47EAYqXbRV");
+        headers.add("ERIC-Authorised-Key-Privileges", "internal-app");
+        headers.set("Content-Type", "application/json");
+
+        HttpEntity<String> request = new HttpEntity<String>(null, headers);
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "/company/{company_number}/internal", HttpMethod.DELETE, request, Void.class, companyNumber);
+        CucumberContext.CONTEXT.set("statusCode", response.getStatusCode().value());
+    }
+
     @And("the company profile does not exist for {string}")
     public void the_company_profile_does_not_exist_for(String companyNumber) {
         assertThat(companyProfileRepository.existsById(companyNumber)).isFalse();

--- a/src/itest/resources/features/delete-company-profile.feature
+++ b/src/itest/resources/features/delete-company-profile.feature
@@ -55,13 +55,13 @@ Feature: Delete company profile
       | 00006400       |
 
 
-  Scenario Outline: Delete psc statement unsuccessfully when kafka-api is not available
+  Scenario Outline: Delete company profile successfully when kafka-api is not available
     Given Company profile api service is running
     And the company profile resource "<data_file>" exists for "<company_number>"
     And CHS kafka API service is unavailable
     When a DELETE request is sent to the company profile endpoint for "<company_number>"
     Then I should receive 503 status code
-    And a company profile exists with id "<company_number>"
+    And the company profile does not exist for "<company_number>"
 
     Examples:
       | data_file               | company_number |

--- a/src/itest/resources/features/delete-company-profile.feature
+++ b/src/itest/resources/features/delete-company-profile.feature
@@ -30,6 +30,23 @@ Feature: Delete company profile
       | company_number |
       | 00006400       |
 
+  Scenario Outline: Delete company profile unsuccessfully - stale delta
+    Given the company profile resource "<data_file>" exists for "<company_number>"
+    When a DELETE request is sent to the company profile endpoint for "<company_number>" with stale delta
+    Then the response code should be 409
+
+    Examples:
+      | data_file           | company_number |
+      | with_links_resource | 00006400       |
+
+  Scenario Outline: Delete company profile unsuccessfully - delta at is blank
+    When a DELETE request is sent to the company profile endpoint for "<company_number>" with blank delta at
+    Then the response code should be 400
+
+    Examples:
+      | company_number |
+      | 00006400       |
+
   @Ignored
     #    Scenario does not work correctly due to potential issue with API Client library and Apache Client 5 dependency
   Scenario Outline: Delete company profile unsuccessfully - company profile resource does not exist

--- a/src/itest/resources/features/delete-company-profile.feature
+++ b/src/itest/resources/features/delete-company-profile.feature
@@ -7,11 +7,20 @@ Feature: Delete company profile
     And the company profile does not exist for "<company_number>"
     Then I should receive 200 status code
 
-
     Examples:
       | data_file               | company_number |
       | with_links_resource     | 00006400       |
-    
+
+  Scenario Outline: Delete company profile successfully - company profile resource does not exist
+    Given the CHS Kafka API is reachable
+    And the company profile does not exist for "<company_number>"
+    When a DELETE request is sent to the company profile endpoint for "<company_number>"
+    Then I should receive 200 status code
+    And the CHS Kafka API is invoked successfully
+
+    Examples:
+      | company_number |
+      | 00006400       |
   
   Scenario Outline: Delete company profile unsuccessfully - user not authenticated
     When a DELETE request is sent to the company profile endpoint for "<company_number>" without valid ERIC headers
@@ -46,18 +55,6 @@ Feature: Delete company profile
     Examples:
       | company_number |
       | 00006400       |
-
-  @Ignored
-    #    Scenario does not work correctly due to potential issue with API Client library and Apache Client 5 dependency
-  Scenario Outline: Delete company profile unsuccessfully - company profile resource does not exist
-    Given a company profile resource does not exist for "<company_number>"
-    When a DELETE request is sent to the company profile endpoint for "<company_number>"
-    Then the response code should be 404
-
-    Examples:
-      | company_number |
-      | 00006400       |
-
 
   Scenario Outline: Delete company profile unsuccessfully while database is down
     Given Company profile api service is running

--- a/src/main/java/uk/gov/companieshouse/company/profile/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/config/ExceptionHandlerConfig.java
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.api.exception.DocumentNotFoundException;
 import uk.gov.companieshouse.api.exception.MethodNotAllowedException;
 import uk.gov.companieshouse.api.exception.ResourceStateConflictException;
 import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company.profile.exception.ConflictException;
 import uk.gov.companieshouse.logging.Logger;
 
 
@@ -145,6 +146,13 @@ public class ExceptionHandlerConfig {
     @ExceptionHandler(value = {ResourceStateConflictException.class})
     public ResponseEntity<Object> handleResourceStateConflictException() {
         return new ResponseEntity<>(HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(value = {ConflictException.class})
+    public ResponseEntity<Object> handleConflictException(Exception ex,
+                                                          WebRequest request) {
+        return new ResponseEntity<>(responseAndLogBuilderHandler(ex, request),
+                HttpStatus.CONFLICT);
     }
 
     private String generateShortCorrelationId() {

--- a/src/main/java/uk/gov/companieshouse/company/profile/config/MongoCompanyProfileConfig.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/config/MongoCompanyProfileConfig.java
@@ -6,18 +6,14 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-@ConditionalOnProperty(name = "mongodb.transactional", havingValue = "true")
 @Configuration
-@EnableTransactionManagement
 public class MongoCompanyProfileConfig extends AbstractMongoClientConfiguration {
 
     @Value("${spring.data.mongodb.collection}")

--- a/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileController.java
@@ -77,7 +77,7 @@ public class CompanyProfileController {
      * @param companyNumber  The company number of the company
      * @return ResponseEntity
      */
-    @PutMapping("/company/{company_number}")
+    @PutMapping("/company/{company_number}/internal")
     public ResponseEntity<Void> processCompanyProfile(
             @RequestHeader("x-request-id") String contextId,
             @PathVariable("company_number") String companyNumber,
@@ -200,23 +200,20 @@ public class CompanyProfileController {
      * @param companyNumber The number of the company
      * @return ResponseEntity
      */
-    @DeleteMapping("/company/{company_number}")
+    @DeleteMapping("/company/{company_number}/internal")
     public ResponseEntity<Void> deleteCompanyProfile(
             @RequestHeader("x-request-id") String contextId,
+            @RequestHeader("X-DELTA-AT") String deltaAt,
             @PathVariable("company_number") String companyNumber) {
         DataMapHolder.get()
                 .companyNumber(companyNumber);
         logger.info(String.format("Deleting company profile with company number %s", companyNumber),
                 DataMapHolder.getLogMap());
         try {
-            companyProfileService.deleteCompanyProfile(contextId, companyNumber);
+            companyProfileService.deleteCompanyProfile(contextId, companyNumber, deltaAt);
             logger.info("Successfully deleted company profile with company number: "
                     + companyNumber, DataMapHolder.getLogMap());
             return ResponseEntity.status(HttpStatus.OK).build();
-        } catch (ResourceNotFoundException resourceNotFoundException) {
-            logger.error("Error while trying to delete company profile.",
-                    resourceNotFoundException, DataMapHolder.getLogMap());
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         } catch (DataAccessException | MongoTimeoutException ex) {
             logger.error("Error while trying to delete company profile.",
                     ex, DataMapHolder.getLogMap());

--- a/src/main/java/uk/gov/companieshouse/company/profile/exception/ConflictException.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/exception/ConflictException.java
@@ -1,0 +1,9 @@
+package uk.gov.companieshouse.company.profile.exception;
+
+public class ConflictException extends RuntimeException {
+
+    public ConflictException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -18,7 +18,6 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.companieshouse.GenerateEtagUtil;
 import uk.gov.companieshouse.api.company.Accounts;
 import uk.gov.companieshouse.api.company.AnnualReturn;
@@ -441,7 +440,7 @@ public class CompanyProfileService {
                     logger.info(String.format("Delete for non-existent document in MongoDb with companyNumber %s",
                             companyNumber), DataMapHolder.getLogMap());
                     companyProfileApiService.invokeChsKafkaApiWithDeleteEvent(contextId, companyNumber,
-                            new Data());
+                            null);
                 }
         );
     }

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -43,6 +43,7 @@ import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.model.CompanyProfileDocument;
 import uk.gov.companieshouse.api.model.Updated;
 import uk.gov.companieshouse.company.profile.api.CompanyProfileApiService;
+import uk.gov.companieshouse.company.profile.exception.ConflictException;
 import uk.gov.companieshouse.company.profile.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.company.profile.logging.DataMapHolder;
 import uk.gov.companieshouse.company.profile.model.UnversionedCompanyProfileDocument;
@@ -405,36 +406,44 @@ public class CompanyProfileService {
     /**
      * Delete company profile.
      */
-    public void deleteCompanyProfile(String contextId, String companyNumber, String deltaAt) {
-        if (StringUtils.isBlank(deltaAt)) {
+    public void deleteCompanyProfile(String contextId, String companyNumber, String requestDeltaAt) {
+        if (StringUtils.isBlank(requestDeltaAt)) {
             logger.error("deltaAt missing from delete request", DataMapHolder.getLogMap());
             throw new BadRequestException("deltaAt is null or empty");
         }
-        // Ask someone about this better to use a try catch for the getCompanyProfileDocument call as it's used by other methods too,
-        // or should change the method itself and fix the other methods in this class that use it
-        try {
-            VersionedCompanyProfileDocument companyProfileDocument = getCompanyProfileDocument(companyNumber);
-            Data companyProfile = companyProfileDocument.getCompanyProfile();
-            String parentCompanyNumber = companyProfileDocument.getParentCompanyNumber();
-            if (parentCompanyNumber != null && companyProfile.getType().equals("uk-establishment")) {
-                LinkRequest ukEstablishmentLinkRequest =
-                        new LinkRequest(contextId, parentCompanyNumber,
-                                UK_ESTABLISHMENTS_LINK_TYPE,
-                                UK_ESTABLISHMENTS_DELTA_TYPE, Links::getUkEstablishments);
-                checkForDeleteLink(ukEstablishmentLinkRequest);
-            }
+        companyProfileRepository.findById(companyNumber).ifPresentOrElse(
+                companyProfileDocument -> {
+                    Data companyProfile = companyProfileDocument.getCompanyProfile();
+                    LocalDateTime existingDeltaAt = companyProfileDocument.getDeltaAt();
+                    if (isDeltaStale(requestDeltaAt, existingDeltaAt)) {
+                        logger.error(String.format(
+                                "Stale delta received; request delta_at: [%s] is not after existing delta_at: [%s]",
+                                requestDeltaAt, existingDeltaAt), DataMapHolder.getLogMap());
+                        throw new ConflictException("Stale delta received");
+                    }
 
-            companyProfileRepository.delete(companyProfileDocument);
-            logger.info(String.format("Company profile is deleted in MongoDb with companyNumber %s",
-                    companyNumber), DataMapHolder.getLogMap());
-            companyProfileApiService.invokeChsKafkaApiWithDeleteEvent(contextId, companyNumber,
-                    companyProfile);
-        } catch (ResourceNotFoundException ex) {
-            logger.info(String.format("Delete for non-existent document in MongoDb with companyNumber %s",
-                    companyNumber), DataMapHolder.getLogMap());
-            companyProfileApiService.invokeChsKafkaApiWithDeleteEvent(contextId, companyNumber,
-                    new Data());
-        }
+                    String parentCompanyNumber = companyProfileDocument.getParentCompanyNumber();
+                    if (parentCompanyNumber != null && companyProfile.getType().equals("uk-establishment")) {
+                        LinkRequest ukEstablishmentLinkRequest =
+                                new LinkRequest(contextId, parentCompanyNumber,
+                                        UK_ESTABLISHMENTS_LINK_TYPE,
+                                        UK_ESTABLISHMENTS_DELTA_TYPE, Links::getUkEstablishments);
+                        checkForDeleteLink(ukEstablishmentLinkRequest);
+                    }
+
+                    companyProfileRepository.delete(companyProfileDocument);
+                    logger.info(String.format("Company profile is deleted in MongoDb with companyNumber %s",
+                            companyNumber), DataMapHolder.getLogMap());
+                    companyProfileApiService.invokeChsKafkaApiWithDeleteEvent(contextId, companyNumber,
+                            companyProfile);
+                },
+                () -> {
+                    logger.info(String.format("Delete for non-existent document in MongoDb with companyNumber %s",
+                            companyNumber), DataMapHolder.getLogMap());
+                    companyProfileApiService.invokeChsKafkaApiWithDeleteEvent(contextId, companyNumber,
+                            new Data());
+                }
+        );
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileConcurrencyITest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileConcurrencyITest.java
@@ -114,7 +114,7 @@ class CompanyProfileConcurrencyITest {
         assertEquals(0, document.getVersion());
 
         // when
-        companyProfileService.deleteCompanyProfile(CONTEXT_ID, COMPANY_NUMBER);
+        companyProfileService.deleteCompanyProfile(CONTEXT_ID, COMPANY_NUMBER, DELTA_AT);
 
         // then
         Optional<VersionedCompanyProfileDocument> actual = companyProfileRepository.findById(COMPANY_NUMBER);
@@ -129,7 +129,7 @@ class CompanyProfileConcurrencyITest {
         mongoTemplate.save(document);
 
         // when
-        companyProfileService.deleteCompanyProfile(CONTEXT_ID, COMPANY_NUMBER);
+        companyProfileService.deleteCompanyProfile(CONTEXT_ID, COMPANY_NUMBER, DELTA_AT);
 
         // then
         Optional<VersionedCompanyProfileDocument> actual = companyProfileRepository.findById(COMPANY_NUMBER);

--- a/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
@@ -1210,30 +1210,6 @@ class CompanyProfileControllerTest {
         verify(companyProfileService).deleteCompanyProfile("123456", MOCK_COMPANY_NUMBER, MOCK_DELTA_AT);
     }
 
-    /**
-     * This case can't be tested right now from what I can tell. The getCompanyProfileDocument method which retrieves
-     * from mongo is currently sitting in the Service class as a private method, which mean I can't have it throw a
-     * ResourceNotFoundError, and the deleteCompanyProfile method no longer throws that error since it should handle
-     * it fine now
-    @Test
-    @DisplayName("Return 200 when no company profile is found")
-    void deleteCompanyProfileNotFound() throws Exception {
-
-        doThrow(ResourceNotFoundException.class).when(companyProfileService).deleteCompanyProfile(anyString(), anyString(), anyString());
-
-        mockMvc.perform(delete(DELETE_COMPANY_PROFILE_URL)
-                        .header("ERIC-Identity", ERIC_IDENTITY)
-                        .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
-                        .contentType(APPLICATION_JSON)
-                        .header("x-request-id", X_REQUEST_ID)
-                        .header("X-DELTA-AT", MOCK_DELTA_AT)
-                        .header("ERIC-Authorised-Key-Privileges", "internal-app"))
-                .andExpect(status().isOk());
-
-        verify(companyProfileService).deleteCompanyProfile("123456", MOCK_COMPANY_NUMBER, MOCK_DELTA_AT);
-    }
-     **/
-
     @Test
     @DisplayName("Return 503 when service is unavailable")
     void deleteCompanyProfileWhenServiceIsUnavailable() throws Exception {

--- a/src/test/java/uk/gov/companieshouse/company/profile/exception/ControllerExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/exception/ControllerExceptionHandlerTest.java
@@ -125,7 +125,8 @@ class ControllerExceptionHandlerTest {
                 Arguments.of(503, "Service unavailable", ServiceUnavailableException.class),
                 Arguments.of(500, "Unexpected exception", IllegalArgumentException.class),
                 Arguments.of(500, "Unexpected exception", RuntimeException.class),
-                Arguments.of(500, "Unexpected exception", NoSuchMethodException.class)
+                Arguments.of(500, "Unexpected exception", NoSuchMethodException.class),
+                Arguments.of(409, "Conflict", ConflictException.class)
         );
     }
 

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -2225,7 +2225,7 @@ class CompanyProfileServiceTest {
 
     @Test
     @DisplayName("When company number is null process without error")
-    public void testDeleteCompanyProfileProcessesInvalidCompanyNumber() {
+    void testDeleteCompanyProfileProcessesInvalidCompanyNumber() {
         when(companyProfileRepository.findById(MOCK_COMPANY_NUMBER)).thenReturn(Optional.empty());
 
         companyProfileService.deleteCompanyProfile("123456", MOCK_COMPANY_NUMBER, MOCK_DELTA_AT);
@@ -2233,7 +2233,7 @@ class CompanyProfileServiceTest {
         verify(companyProfileRepository, times(1)).findById(MOCK_COMPANY_NUMBER);
         verifyNoMoreInteractions(companyProfileRepository);
         verify(companyProfileService, times((0))).checkForDeleteLink(any());
-        verify(companyProfileApiService).invokeChsKafkaApiWithDeleteEvent("123456", MOCK_COMPANY_NUMBER, new Data());
+        verify(companyProfileApiService).invokeChsKafkaApiWithDeleteEvent("123456", MOCK_COMPANY_NUMBER, null);
     }
 
     @Test


### PR DESCRIPTION
* Add internal to PUT and DELETE endpoints
* Add stale delta check to DELETE processing
* Handle resource not found error in DELETE
* Call chs-kafka-api on DELETEs where no data exists in mongo
* Create ConflictException class
* Update tests

Resolves [DSND-3110](https://companieshouse.atlassian.net/browse/DSND-3110)

[DSND-3110]: https://companieshouse.atlassian.net/browse/DSND-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ