### PR TITLE
DSND-3226:  Fix FC and BR companies deltaAt ordering bug

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileLinksE2EITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileLinksE2EITest.java
@@ -44,7 +44,7 @@ import java.util.Objects;
 @Testcontainers
 @AutoConfigureMockMvc
 @SpringBootTest(classes = CompanyProfileApiApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-class CompanyProfileE2EITest {
+class CompanyProfileLinksE2EITest {
 
     private static final String COMPANY_NUMBER = "12345678";
     private static final String UK_ESTABLISHMENTS_LINK = String.format("/company/%s/uk-establishments", COMPANY_NUMBER);

--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfilePUTE2EITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfilePUTE2EITest.java
@@ -170,6 +170,7 @@ class CompanyProfilePUTE2EITest {
         assertEquals(UK_ESTABLISHMENT_LINK, parentDocument.getCompanyProfile().getLinks().getUkEstablishments());
         assertEquals(OVERSEA_COMPANY_TYPE, parentDocument.getCompanyProfile().getType());
         assertEquals(1L, parentDocument.getVersion());
+        verify(companyProfileApiService).invokeChsKafkaApi(CONTEXT_ID, PARENT_COMPANY_NUMBER);
     }
 
     @Test
@@ -197,6 +198,7 @@ class CompanyProfilePUTE2EITest {
         assertNull(parentDocument.getCompanyProfile().getLinks().getUkEstablishments());
         assertEquals(OVERSEA_COMPANY_TYPE, parentDocument.getCompanyProfile().getType());
         assertEquals(0L, parentDocument.getVersion());
+        verify(companyProfileApiService).invokeChsKafkaApi(CONTEXT_ID, PARENT_COMPANY_NUMBER);
     }
 
     @Test
@@ -232,6 +234,7 @@ class CompanyProfilePUTE2EITest {
         assertEquals(UK_ESTABLISHMENT_LINK, parentDocument.getCompanyProfile().getLinks().getUkEstablishments());
         assertEquals(OVERSEA_COMPANY_TYPE, parentDocument.getCompanyProfile().getType());
         assertEquals(1L, parentDocument.getVersion());
+        verify(companyProfileApiService).invokeChsKafkaApi(CONTEXT_ID, PARENT_COMPANY_NUMBER);
 
 
         final VersionedCompanyProfileDocument childDocument = Objects.requireNonNull(mongoTemplate.findById(COMPANY_NUMBER, VersionedCompanyProfileDocument.class));

--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfilePUTE2EITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfilePUTE2EITest.java
@@ -1,0 +1,330 @@
+package uk.gov.companieshouse.company.profile.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Valid;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.gov.companieshouse.api.company.AccountingReferenceDate;
+import uk.gov.companieshouse.api.company.AccountingRequirement;
+import uk.gov.companieshouse.api.company.Accounts;
+import uk.gov.companieshouse.api.company.BranchCompanyDetails;
+import uk.gov.companieshouse.api.company.CompanyProfile;
+import uk.gov.companieshouse.api.company.Data;
+import uk.gov.companieshouse.api.company.ForeignCompanyDetails;
+import uk.gov.companieshouse.api.company.LastAccounts;
+import uk.gov.companieshouse.api.company.Links;
+import uk.gov.companieshouse.api.company.NextAccounts;
+import uk.gov.companieshouse.api.company.OriginatingRegistry;
+import uk.gov.companieshouse.api.company.PreviousCompanyNames;
+import uk.gov.companieshouse.api.company.RegisteredOfficeAddress;
+import uk.gov.companieshouse.company.profile.CompanyProfileApiApplication;
+import uk.gov.companieshouse.company.profile.api.CompanyProfileApiService;
+import uk.gov.companieshouse.company.profile.model.VersionedCompanyProfileDocument;
+import uk.gov.companieshouse.company.profile.repository.CompanyProfileRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Testcontainers
+@AutoConfigureMockMvc
+@SpringBootTest(classes = CompanyProfileApiApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class CompanyProfilePUTE2EITest {
+
+    private static final String COMPANY_NUMBER = "BR005209";
+    private static final String PARENT_COMPANY_NUMBER = "FC022112";
+    private static final String CONTEXT_ID = "context_id";
+    private static final String PUT_ENDPOINT = "/company/{company_number}/internal";
+    private static final String UK_ESTABLISHMENT_TYPE = "uk-establishment";
+    private static final String OVERSEA_COMPANY_TYPE = "oversea-company";
+    private static final String CHILD_SELF_LINK = String.format("/company/%s", COMPANY_NUMBER);
+    private static final String PARENT_SELF_LINK = String.format("/company/%s", PARENT_COMPANY_NUMBER);
+    private static final String UK_ESTABLISHMENT_LINK = String.format("/company/%s/uk-establishments", PARENT_COMPANY_NUMBER);
+
+    @Container
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5.0.12");
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+    @Autowired
+    private CompanyProfileRepository companyProfileRepository;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CompanyProfileApiService companyProfileApiService;
+
+    @BeforeAll
+    static void start() {
+        System.setProperty("spring.data.mongodb.uri", mongoDBContainer.getReplicaSetUrl());
+    }
+
+    @BeforeEach
+    void setup() {
+        companyProfileRepository.deleteAll();
+    }
+
+
+    @Test
+    void shouldPersistBaseParentFCCompanyProfileCorrectlyWhenBRDeltaReceivedOnPUTEndpoint() throws Exception {
+        // given
+        final String oldEtag = "oldEtag";
+        CompanyProfile request = makeBRPutRequest();
+
+        // when
+        final ResultActions result = mockMvc.perform(put(PUT_ENDPOINT, COMPANY_NUMBER)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .header("x-request-id", CONTEXT_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+
+        final VersionedCompanyProfileDocument childDocument = Objects.requireNonNull(mongoTemplate.findById(COMPANY_NUMBER, VersionedCompanyProfileDocument.class));
+        final Data childCompanyProfile = childDocument.getCompanyProfile();
+
+        final VersionedCompanyProfileDocument baseParentDocument = mongoTemplate.findById(PARENT_COMPANY_NUMBER, VersionedCompanyProfileDocument.class);
+
+        assertNotNull(baseParentDocument);
+        assertNull(baseParentDocument.getDeltaAt());
+        assertEquals(UK_ESTABLISHMENT_LINK, baseParentDocument.getCompanyProfile().getLinks().getUkEstablishments());
+        assertEquals(0L, baseParentDocument.getVersion());
+
+        assertEquals(CHILD_SELF_LINK, childCompanyProfile.getLinks().getSelf());
+        assertEquals(PARENT_SELF_LINK, childCompanyProfile.getLinks().getOverseas());
+        assertNotNull(childDocument.getUpdated().getAt());
+        assertEquals(UK_ESTABLISHMENT_TYPE, childCompanyProfile.getType());
+        assertEquals(0L, childDocument.getVersion());
+        assertNotEquals(oldEtag, childCompanyProfile.getEtag());
+        verify(companyProfileApiService).invokeChsKafkaApi(CONTEXT_ID, COMPANY_NUMBER);
+    }
+
+    @Test
+    void shouldUpdateBaseFCCompanyProfileRegardlessOfDeltaAtTime() throws Exception {
+        // given
+        VersionedCompanyProfileDocument document = new VersionedCompanyProfileDocument();
+        document.setId(PARENT_COMPANY_NUMBER)
+                .setCompanyProfile(new Data()
+                        .links(new Links()
+                                .ukEstablishments(UK_ESTABLISHMENT_LINK)));
+        document.version(0L);
+        companyProfileRepository.insert(document);
+
+        CompanyProfile request = makeFCPutRequest();
+        // when
+        final ResultActions result = mockMvc.perform(put(PUT_ENDPOINT, PARENT_COMPANY_NUMBER)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .header("x-request-id", CONTEXT_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+
+        final VersionedCompanyProfileDocument parentDocument = mongoTemplate.findById(PARENT_COMPANY_NUMBER, VersionedCompanyProfileDocument.class);
+
+        assertNotNull(parentDocument);
+        assertNotNull(parentDocument.getDeltaAt());
+        assertEquals(PARENT_SELF_LINK, parentDocument.getCompanyProfile().getLinks().getSelf());
+        assertEquals(UK_ESTABLISHMENT_LINK, parentDocument.getCompanyProfile().getLinks().getUkEstablishments());
+        assertEquals(OVERSEA_COMPANY_TYPE, parentDocument.getCompanyProfile().getType());
+        assertEquals(1L, parentDocument.getVersion());
+
+        final VersionedCompanyProfileDocument childDocument = Objects.requireNonNull(mongoTemplate.findById(COMPANY_NUMBER, VersionedCompanyProfileDocument.class));
+        final Data childCompanyProfile = childDocument.getCompanyProfile();
+
+        assertEquals(CHILD_SELF_LINK, childCompanyProfile.getLinks().getSelf());
+        assertEquals(PARENT_SELF_LINK, childCompanyProfile.getLinks().getOverseas());
+        assertNotNull(childDocument.getUpdated().getAt());
+        assertEquals(UK_ESTABLISHMENT_TYPE, childCompanyProfile.getType());
+        assertEquals(0L, childDocument.getVersion());
+        assertNotEquals(oldEtag, childCompanyProfile.getEtag());
+        verify(companyProfileApiService).invokeChsKafkaApi(CONTEXT_ID, COMPANY_NUMBER);
+    }
+
+    @Test
+    void shouldPersistFCCompanyProfileCorrectlyIfProcessedBeforeBCCompany() throws Exception {
+        // given
+        CompanyProfile request = makeFCPutRequest();
+
+        // when
+        final ResultActions result = mockMvc.perform(put(PUT_ENDPOINT, PARENT_COMPANY_NUMBER)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .header("x-request-id", CONTEXT_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+
+        final VersionedCompanyProfileDocument parentDocument = mongoTemplate.findById(PARENT_COMPANY_NUMBER, VersionedCompanyProfileDocument.class);
+
+        assertNotNull(parentDocument);
+        assertNotNull(parentDocument.getDeltaAt());
+        assertEquals(PARENT_SELF_LINK, parentDocument.getCompanyProfile().getLinks().getSelf());
+        assertNull(parentDocument.getCompanyProfile().getLinks().getUkEstablishments());
+        assertEquals(OVERSEA_COMPANY_TYPE, parentDocument.getCompanyProfile().getType());
+        assertEquals(0L, parentDocument.getVersion());
+    }
+
+    @Test
+    void shouldAddUKEstablishmentsLinkToFCCompanyIfBCDeltaProcessedSecond() throws Exception {
+        // given
+        VersionedCompanyProfileDocument document = new VersionedCompanyProfileDocument();
+        document.setId(PARENT_COMPANY_NUMBER)
+                .setCompanyProfile(makeFCPutRequest().getData())
+                .setDeltaAt(LocalDateTime.parse("20250121064805856963"));
+        document.setHasMortgages(false);
+        document.version(0L);
+
+        companyProfileRepository.insert(document);
+        CompanyProfile request = makeBRPutRequest();
+
+        // when
+        final ResultActions result = mockMvc.perform(put(PUT_ENDPOINT, COMPANY_NUMBER)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .header("x-request-id", CONTEXT_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+
+        final VersionedCompanyProfileDocument parentDocument = mongoTemplate.findById(PARENT_COMPANY_NUMBER, VersionedCompanyProfileDocument.class);
+
+        assertNotNull(parentDocument);
+        assertNotNull(parentDocument.getDeltaAt());
+        assertEquals(PARENT_SELF_LINK, parentDocument.getCompanyProfile().getLinks().getSelf());
+        assertEquals(UK_ESTABLISHMENT_LINK, parentDocument.getCompanyProfile().getLinks().getUkEstablishments());
+        assertEquals(OVERSEA_COMPANY_TYPE, parentDocument.getCompanyProfile().getType());
+        assertEquals(0L, parentDocument.getVersion());
+
+
+
+    }
+
+    private CompanyProfile makeBRPutRequest() {
+        return new CompanyProfile()
+                .data(new Data()
+                        .branchCompanyDetails(new BranchCompanyDetails()
+                                .businessActivity("Custom Software Consulting, Research & Development")
+                                .parentCompanyName("PRECISE SOLUTION (CJR TEST1)")
+                                .parentCompanyNumber(PARENT_COMPANY_NUMBER))
+                        .companyName("PRECISE SOLUTION (CJR TEST1)")
+                        .companyNumber("BR005209")
+                        .companyStatus("open")
+                        .dateOfCreation(LocalDate.parse("1999-10-11"))
+                        .hasCharges(null)
+                        .links(new Links()
+                                .self("/company/BR005209"))
+                        .registeredOfficeAddress(new RegisteredOfficeAddress()
+                                .addressLine1("Masters Lodge, Ste 3")
+                                .locality("London")
+                                .postalCode("E1 0BE")
+                                .region("Johnson Street"))
+                        .type("uk-establishment")
+                        .hasSuperSecurePscs(false))
+                .hasMortgages(false)
+                .parentCompanyNumber(PARENT_COMPANY_NUMBER)
+                .deltaAt("20250121164805856963");
+    }
+
+    private CompanyProfile makeFCPutRequest() {
+        return new CompanyProfile()
+                .data(new Data()
+                        .accounts(makeAccounts())
+                        .companyName("PRECISE SOLUTION (CJR TEST1)")
+                        .companyNumber("FC022112")
+                        .companyStatus("active")
+                        .dateOfCreation(LocalDate.parse("1999-10-11"))
+                        .externalRegistrationNumber("21343-1995")
+                        .foreignCompanyDetails(makeForeignCompanyDetails())
+                        .hasInsolvencyHistory(false)
+                        .links(new Links()
+                                .self(PARENT_SELF_LINK))
+                        .previousCompanyNames(makePreviousCompanyNamesList())
+                        .registeredOfficeAddress(new RegisteredOfficeAddress()
+                                .addressLine1("1905 South Eastern Avenue")
+                                .addressLine2("Las Vegas")
+                                .country("United States")
+                                .locality("Nv 89104  Nevada")
+                                .region("Usa"))
+                        .registeredOfficeIsInDispute(false)
+                        .type("oversea-company")
+                        .undeliverableRegisteredOfficeAddress(false)
+                        .hasSuperSecurePscs(false)
+                )
+                .hasMortgages(false)
+                .deltaAt("20250121064805856963");
+    }
+
+    private static Accounts makeAccounts() {
+        return new Accounts()
+                .accountingReferenceDate(new AccountingReferenceDate()
+                        .day("31")
+                        .month("12"))
+                .lastAccounts(new LastAccounts()
+                        .madeUpTo(LocalDate.parse("2013-12-31"))
+                        .periodEndOn(LocalDate.parse("2013-12-31"))
+                        .type("full"))
+                .nextAccounts(new NextAccounts()
+                        .periodEndOn(LocalDate.parse("2014-12-31")))
+                .nextMadeUpTo(LocalDate.parse("2014-12-31"));
+    }
+
+    private static ForeignCompanyDetails makeForeignCompanyDetails() {
+        return new ForeignCompanyDetails()
+                .accountingRequirement(new AccountingRequirement()
+                        .foreignAccountType("accounting-requirements-of-originating-country-do-not-apply")
+                        .termsOfAccountPublication("accounting-reference-date-allocated-by-companies-house"))
+                .businessActivity("Data Processing & Research")
+                .governedBy("Chapter 78 Of The State Of Nevada Revised Statutes")
+                .isACreditFinancialInstitution(false)
+                .originatingRegistry(new OriginatingRegistry()
+                        .country("UNITED STATES")
+                        .name("State Of Nevada Secretary Of State Office"))
+                .registrationNumber("21343-1995")
+                .legalForm("Us Limited Liabioity \"C\" Corporation, Private Ownership");
+    }
+
+    private List<@Valid PreviousCompanyNames> makePreviousCompanyNamesList() {
+        ArrayList<PreviousCompanyNames> companyNames = new ArrayList<>();
+        companyNames.add(new PreviousCompanyNames()
+                .name("PRECISE SOLUTION")
+                .effectiveFrom(LocalDate.parse("1999-11-02"))
+                .ceasedOn(LocalDate.parse("2025-01-16")));
+        return companyNames;
+    }
+}

--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfilePUTE2EITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfilePUTE2EITest.java
@@ -170,7 +170,6 @@ class CompanyProfilePUTE2EITest {
         assertEquals(UK_ESTABLISHMENT_LINK, parentDocument.getCompanyProfile().getLinks().getUkEstablishments());
         assertEquals(OVERSEA_COMPANY_TYPE, parentDocument.getCompanyProfile().getType());
         assertEquals(1L, parentDocument.getVersion());
-
     }
 
     @Test
@@ -245,8 +244,6 @@ class CompanyProfilePUTE2EITest {
         assertEquals(0L, childDocument.getVersion());
         assertNotEquals(OLD_ETAG, childCompanyProfile.getEtag());
         verify(companyProfileApiService).invokeChsKafkaApi(CONTEXT_ID, COMPANY_NUMBER);
-
-
     }
 
     private CompanyProfile makeBRPutRequest(String deltaAt) {

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -636,7 +636,6 @@ public class CompanyProfileService {
     private VersionedCompanyProfileDocument createParentCompanyDocument(String parentCompanyNumber) {
         VersionedCompanyProfileDocument parentCompanyDocument = new VersionedCompanyProfileDocument();
         parentCompanyDocument.setId(parentCompanyNumber);
-        parentCompanyDocument.setDeltaAt(LocalDateTime.now());
         Data parentCompanyData = new Data();
         Links parentCompanyLinks = new Links();
         String ukEstablishmentLink = String.format("/company/%s/uk-establishments",

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -2716,6 +2716,11 @@ class CompanyProfileServiceTest {
     }
 
     @Test
+    void shouldSaveParentFCDocumentWhenBRdeltaSent() {
+
+    }
+
+    @Test
     void updateCompanyProfileWhenHasChargesIsFalse() {
         CompanyProfile companyProfile = new CompanyProfile()
                 .deltaAt(DELTA_AT);

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -2716,11 +2716,6 @@ class CompanyProfileServiceTest {
     }
 
     @Test
-    void shouldSaveParentFCDocumentWhenBRdeltaSent() {
-
-    }
-
-    @Test
     void updateCompanyProfileWhenHasChargesIsFalse() {
         CompanyProfile companyProfile = new CompanyProfile()
                 .deltaAt(DELTA_AT);


### PR DESCRIPTION
* deltaAt now not persisted on parent companies so that regardless of processing order parent company details will still be persisted.
* a suite of integration tests added so that behaviour of FC and BR companies sure to be correct. 

Locally tested with all scenarios.


[DSND-3226](https://companieshouse.atlassian.net/browse/DSND-3226)

[DSND-3226]: https://companieshouse.atlassian.net/browse/DSND-3226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ