### PR TITLE
DSND-3226: Fix deletion of child BR document

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileFullE2EITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileFullE2EITest.java
@@ -55,7 +55,7 @@ import java.util.Objects;
 @Testcontainers
 @AutoConfigureMockMvc
 @SpringBootTest(classes = CompanyProfileApiApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-class CompanyProfilePUTE2EITest {
+class CompanyProfileFullE2EITest {
 
     private static final String CHILD_COMPANY_NUMBER = "BR005209";
     private static final String PARENT_COMPANY_NUMBER = "FC022112";

--- a/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfilePUTE2EITest.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/controller/CompanyProfilePUTE2EITest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,19 +57,20 @@ import java.util.Objects;
 @SpringBootTest(classes = CompanyProfileApiApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 class CompanyProfilePUTE2EITest {
 
-    private static final String COMPANY_NUMBER = "BR005209";
+    private static final String CHILD_COMPANY_NUMBER = "BR005209";
     private static final String PARENT_COMPANY_NUMBER = "FC022112";
     private static final String CONTEXT_ID = "context_id";
     private static final String PUT_ENDPOINT = "/company/{company_number}/internal";
+    private static final String DELETE_ENDPOINT = "/company/{company_number}/internal";
     private static final String UK_ESTABLISHMENT_TYPE = "uk-establishment";
     private static final String OVERSEA_COMPANY_TYPE = "oversea-company";
-    private static final String CHILD_SELF_LINK = String.format("/company/%s", COMPANY_NUMBER);
+    private static final String CHILD_SELF_LINK = String.format("/company/%s", CHILD_COMPANY_NUMBER);
     private static final String PARENT_SELF_LINK = String.format("/company/%s", PARENT_COMPANY_NUMBER);
     private static final String UK_ESTABLISHMENT_LINK = String.format("/company/%s/uk-establishments", PARENT_COMPANY_NUMBER);
     private static final String OLD_ETAG = "oldEtag";
     private static final String STALE_DELTA_AT = "20250121064805856963";
-    private static final String DELTA_AT = "20250121164805856963";
-    private static final String NEW_DELTA_AT = "20250121154805856963";
+    private static final String DELTA_AT = "20250121154805856963";
+    private static final String NEW_DELTA_AT = "20250121174805856963";
     private static final DateTimeFormatter DELTA_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS")
             .withZone(UTC);
 
@@ -104,7 +106,7 @@ class CompanyProfilePUTE2EITest {
         CompanyProfile request = makeBRPutRequest(DELTA_AT);
 
         // when
-        final ResultActions result = mockMvc.perform(put(PUT_ENDPOINT, COMPANY_NUMBER)
+        final ResultActions result = mockMvc.perform(put(PUT_ENDPOINT, CHILD_COMPANY_NUMBER)
                 .header("ERIC-Identity", "123")
                 .header("ERIC-Identity-Type", "key")
                 .header("ERIC-Authorised-Key-Privileges", "internal-app")
@@ -115,7 +117,7 @@ class CompanyProfilePUTE2EITest {
         // then
         result.andExpect(MockMvcResultMatchers.status().isOk());
 
-        final VersionedCompanyProfileDocument childDocument = Objects.requireNonNull(mongoTemplate.findById(COMPANY_NUMBER, VersionedCompanyProfileDocument.class));
+        final VersionedCompanyProfileDocument childDocument = Objects.requireNonNull(mongoTemplate.findById(CHILD_COMPANY_NUMBER, VersionedCompanyProfileDocument.class));
         final Data childCompanyProfile = childDocument.getCompanyProfile();
 
         final VersionedCompanyProfileDocument baseParentDocument = mongoTemplate.findById(PARENT_COMPANY_NUMBER, VersionedCompanyProfileDocument.class);
@@ -131,7 +133,7 @@ class CompanyProfilePUTE2EITest {
         assertEquals(UK_ESTABLISHMENT_TYPE, childCompanyProfile.getType());
         assertEquals(0L, childDocument.getVersion());
         assertNotEquals(OLD_ETAG, childCompanyProfile.getEtag());
-        verify(companyProfileApiService).invokeChsKafkaApi(CONTEXT_ID, COMPANY_NUMBER);
+        verify(companyProfileApiService).invokeChsKafkaApi(CONTEXT_ID, CHILD_COMPANY_NUMBER);
     }
 
     @ParameterizedTest
@@ -215,7 +217,7 @@ class CompanyProfilePUTE2EITest {
         CompanyProfile request = makeBRPutRequest(STALE_DELTA_AT);
 
         // when
-        final ResultActions result = mockMvc.perform(put(PUT_ENDPOINT, COMPANY_NUMBER)
+        final ResultActions result = mockMvc.perform(put(PUT_ENDPOINT, CHILD_COMPANY_NUMBER)
                 .header("ERIC-Identity", "123")
                 .header("ERIC-Identity-Type", "key")
                 .header("ERIC-Authorised-Key-Privileges", "internal-app")
@@ -237,7 +239,7 @@ class CompanyProfilePUTE2EITest {
         verify(companyProfileApiService).invokeChsKafkaApi(CONTEXT_ID, PARENT_COMPANY_NUMBER);
 
 
-        final VersionedCompanyProfileDocument childDocument = Objects.requireNonNull(mongoTemplate.findById(COMPANY_NUMBER, VersionedCompanyProfileDocument.class));
+        final VersionedCompanyProfileDocument childDocument = Objects.requireNonNull(mongoTemplate.findById(CHILD_COMPANY_NUMBER, VersionedCompanyProfileDocument.class));
         final Data childCompanyProfile = childDocument.getCompanyProfile();
 
         assertEquals(CHILD_SELF_LINK, childCompanyProfile.getLinks().getSelf());
@@ -246,7 +248,140 @@ class CompanyProfilePUTE2EITest {
         assertEquals(UK_ESTABLISHMENT_TYPE, childCompanyProfile.getType());
         assertEquals(0L, childDocument.getVersion());
         assertNotEquals(OLD_ETAG, childCompanyProfile.getEtag());
-        verify(companyProfileApiService).invokeChsKafkaApi(CONTEXT_ID, COMPANY_NUMBER);
+        verify(companyProfileApiService).invokeChsKafkaApi(CONTEXT_ID, CHILD_COMPANY_NUMBER);
+    }
+
+    @Test
+    void shouldDeleteBaseFCOverseaCompanyIfDeleteDeltaReceived() throws Exception {
+        // given
+        VersionedCompanyProfileDocument document = new VersionedCompanyProfileDocument();
+        document.setId(PARENT_COMPANY_NUMBER)
+                .setCompanyProfile(new Data()
+                        .links(new Links()
+                                .ukEstablishments(UK_ESTABLISHMENT_LINK)));
+        document.version(0L);
+        companyProfileRepository.insert(document);
+
+        // when
+        final ResultActions result = mockMvc.perform(delete(DELETE_ENDPOINT, PARENT_COMPANY_NUMBER)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .header("x-request-id", CONTEXT_ID)
+                .header("X-DELTA-AT", DELTA_AT)
+                .contentType(MediaType.APPLICATION_JSON));
+
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+
+        final VersionedCompanyProfileDocument parentDocument = mongoTemplate.findById(PARENT_COMPANY_NUMBER, VersionedCompanyProfileDocument.class);
+
+        assertNull(parentDocument);
+        verify(companyProfileApiService).invokeChsKafkaApiWithDeleteEvent(CONTEXT_ID, PARENT_COMPANY_NUMBER, document.getCompanyProfile());
+    }
+
+    @Test
+    void shouldDeleteFCParentOverseaCompanyIfDeleteDeltaReceived() throws Exception {
+        // given
+        VersionedCompanyProfileDocument document = new VersionedCompanyProfileDocument();
+        document.setId(PARENT_COMPANY_NUMBER)
+                .setCompanyProfile(makeFCPutRequest(DELTA_AT).getData())
+                .setDeltaAt(LocalDateTime.parse(DELTA_AT, DELTA_AT_FORMATTER));
+        document.setHasMortgages(false);
+        document.version(0L);
+
+        companyProfileRepository.insert(document);
+
+        // when
+        final ResultActions result = mockMvc.perform(delete(DELETE_ENDPOINT, PARENT_COMPANY_NUMBER)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .header("x-request-id", CONTEXT_ID)
+                .header("X-DELTA-AT", DELTA_AT)
+                .contentType(MediaType.APPLICATION_JSON));
+
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+
+        final VersionedCompanyProfileDocument parentDocument = mongoTemplate.findById(PARENT_COMPANY_NUMBER, VersionedCompanyProfileDocument.class);
+
+        assertNull(parentDocument);
+        verify(companyProfileApiService).invokeChsKafkaApiWithDeleteEvent(CONTEXT_ID, PARENT_COMPANY_NUMBER, document.getCompanyProfile());
+    }
+
+    @Test
+    void shouldDeleteBRChildUkEstablishmentIfDeleteDeltaReceivedAndParentNotPresent() throws Exception {
+        // given
+        VersionedCompanyProfileDocument document = new VersionedCompanyProfileDocument();
+        document.setId(CHILD_COMPANY_NUMBER)
+                .setCompanyProfile(makeBRPutRequest(DELTA_AT).getData())
+                .setDeltaAt(LocalDateTime.parse(DELTA_AT, DELTA_AT_FORMATTER));
+        document.setHasMortgages(false);
+        document.version(0L);
+
+        companyProfileRepository.insert(document);
+
+        // when
+        final ResultActions result = mockMvc.perform(delete(DELETE_ENDPOINT, CHILD_COMPANY_NUMBER)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .header("x-request-id", CONTEXT_ID)
+                .header("X-DELTA-AT", NEW_DELTA_AT)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+
+        final VersionedCompanyProfileDocument childDocument = mongoTemplate.findById(CHILD_COMPANY_NUMBER, VersionedCompanyProfileDocument.class);
+
+        assertNull(childDocument);
+        verify(companyProfileApiService).invokeChsKafkaApiWithDeleteEvent(CONTEXT_ID, CHILD_COMPANY_NUMBER, document.getCompanyProfile());
+    }
+
+    @Test
+    void shouldDeleteBRChildUkEstablishmentAndLinkFromParentIfDeleteDeltaReceivedAndParentStillPresent() throws Exception {
+        // given
+        VersionedCompanyProfileDocument parentDocument = new VersionedCompanyProfileDocument();
+        parentDocument.setId(PARENT_COMPANY_NUMBER)
+                .setCompanyProfile(makeFCPutRequest(DELTA_AT).getData())
+                .setDeltaAt(LocalDateTime.parse(DELTA_AT, DELTA_AT_FORMATTER));
+        parentDocument.setHasMortgages(false);
+        parentDocument.version(0L);
+
+        VersionedCompanyProfileDocument document = new VersionedCompanyProfileDocument();
+        document.setId(CHILD_COMPANY_NUMBER)
+                .setCompanyProfile(makeBRPutRequest(DELTA_AT).getData())
+                .setDeltaAt(LocalDateTime.parse(DELTA_AT, DELTA_AT_FORMATTER));
+        document.setHasMortgages(false);
+        document.version(0L);
+
+        companyProfileRepository.insert(parentDocument);
+        companyProfileRepository.insert(document);
+
+        // when
+        final ResultActions result = mockMvc.perform(delete(DELETE_ENDPOINT, CHILD_COMPANY_NUMBER)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .header("x-request-id", CONTEXT_ID)
+                .header("X-DELTA-AT", NEW_DELTA_AT)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+
+        final VersionedCompanyProfileDocument parentRetrieved = mongoTemplate.findById(PARENT_COMPANY_NUMBER, VersionedCompanyProfileDocument.class);
+        final VersionedCompanyProfileDocument childDocument = mongoTemplate.findById(CHILD_COMPANY_NUMBER, VersionedCompanyProfileDocument.class);
+
+        assertNotNull(parentRetrieved);
+        assertNotNull(parentRetrieved.getCompanyProfile().getLinks().getSelf());
+        assertNull(parentRetrieved.getCompanyProfile().getLinks().getUkEstablishments());
+        assertNull(childDocument);
+        verify(companyProfileApiService).invokeChsKafkaApiWithDeleteEvent(CONTEXT_ID, CHILD_COMPANY_NUMBER, document.getCompanyProfile());
     }
 
     private CompanyProfile makeBRPutRequest(String deltaAt) {

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -268,6 +268,32 @@ public class CompanyProfileService {
         }
     }
 
+    public void checkForDeleteLinkUkEstablishmentParent(LinkRequest linkRequest) {
+        Optional<VersionedCompanyProfileDocument> existingDocumentOptional =
+                companyProfileRepository.findById(linkRequest.getCompanyNumber());
+
+        if (existingDocumentOptional.isPresent()) {
+            Data data = existingDocumentOptional
+                    .map(CompanyProfileDocument::getCompanyProfile).orElseThrow(() ->
+                            new ResourceNotFoundException(HttpStatus.NOT_FOUND,
+                                    "no data for company profile: "
+                                            + linkRequest.getCompanyNumber()));
+            Links links = Optional.ofNullable(data.getLinks()).orElseThrow(() ->
+                    new ResourceStateConflictException("links data not found"));
+            String linkData = linkRequest.getCheckLink().apply(links);
+
+            if (isBlank(linkData)) {
+                logger.error(linkRequest.getLinkType() + " link for company profile already"
+                        + " does not exist", DataMapHolder.getLogMap());
+                throw new ResourceStateConflictException("Resource state conflict; "
+                        + linkRequest.getLinkType() + " link already does not exist");
+            } else {
+                deleteLink(linkRequest, existingDocumentOptional.get());
+            }
+        }
+        logger.info("No document found for parent profile, continuing to delete child Uk establishment");
+    }
+
     /**
      * Finds existing company profile from db if any and updates or saves new record into db.
      */
@@ -427,7 +453,8 @@ public class CompanyProfileService {
                                 new LinkRequest(contextId, parentCompanyNumber,
                                         UK_ESTABLISHMENTS_LINK_TYPE,
                                         UK_ESTABLISHMENTS_DELTA_TYPE, Links::getUkEstablishments);
-                        checkForDeleteLink(ukEstablishmentLinkRequest);
+                        // As business logic is different, a different check from others is needed.
+                        checkForDeleteLinkUkEstablishmentParent(ukEstablishmentLinkRequest);
                     }
 
                     companyProfileRepository.delete(companyProfileDocument);

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -290,8 +290,9 @@ public class CompanyProfileService {
             } else {
                 deleteLink(linkRequest, existingDocumentOptional.get());
             }
+        } else {
+            logger.info("No document found for parent profile, continuing to delete child Uk establishment");
         }
-        logger.info("No document found for parent profile, continuing to delete child Uk establishment");
     }
 
     /**
@@ -453,7 +454,7 @@ public class CompanyProfileService {
                                 new LinkRequest(contextId, parentCompanyNumber,
                                         UK_ESTABLISHMENTS_LINK_TYPE,
                                         UK_ESTABLISHMENTS_DELTA_TYPE, Links::getUkEstablishments);
-                        // As business logic is different, a different check from others is needed.
+                        // Business logic states UK establishments need deletion even if the parent document is not present
                         checkForDeleteLinkUkEstablishmentParent(ukEstablishmentLinkRequest);
                     }
 

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -95,6 +95,7 @@ class CompanyProfileServiceTest {
     private static final String MOCK_PARENT_COMPANY_NUMBER = "321033";
     private static final String ANOTHER_PARENT_COMPANY_NUMBER = "FC123456";
     private static final String MOCK_DELTA_AT = "20241129123010123789";
+    private static final String UK_ESTABLISHMENT_COMPANY_NUMBER = "BR765432";
 
     @Mock
     CompanyProfileRepository companyProfileRepository;
@@ -2210,17 +2211,33 @@ class CompanyProfileServiceTest {
 
     @Test
     @DisplayName("Check delete link should be called when deleting Uk establishments")
-    public void testDeleteCompanyProfileUkEstablishments() {
-        when(companyProfileRepository.findById(MOCK_COMPANY_NUMBER)).
+    void testDeleteCompanyProfileUkEstablishments() {
+        when(companyProfileRepository.findById(UK_ESTABLISHMENT_COMPANY_NUMBER)).
                 thenReturn(Optional.ofNullable(EXISTING_UK_ESTABLISHMENT_COMPANY));
         when(companyProfileRepository.findById(ANOTHER_PARENT_COMPANY_NUMBER))
                 .thenReturn(Optional.ofNullable(EXISTING_PARENT_COMPANY));
-        companyProfileService.deleteCompanyProfile("123456", MOCK_COMPANY_NUMBER, MOCK_DELTA_AT);
+        companyProfileService.deleteCompanyProfile("123456", UK_ESTABLISHMENT_COMPANY_NUMBER, MOCK_DELTA_AT);
 
-        verify(companyProfileRepository, times(1)).findById(MOCK_COMPANY_NUMBER);
+        verify(companyProfileRepository, times(1)).findById(UK_ESTABLISHMENT_COMPANY_NUMBER);
         verify(companyProfileRepository, times(1)).findById(ANOTHER_PARENT_COMPANY_NUMBER);
+        verify(companyProfileService, times(1)).checkForDeleteLinkUkEstablishmentParent(any());
         verify(companyProfileRepository, times(1)).delete(EXISTING_UK_ESTABLISHMENT_COMPANY);
-        verify(companyProfileService, times(1)).checkForDeleteLink(any());
+    }
+
+    @Test
+    @DisplayName("Check that child Uk establishment should still be deleted when parent is not found")
+    void shouldStillDeleteChildUkEstablishmentWhenParentNotFound() {
+        when(companyProfileRepository.findById(UK_ESTABLISHMENT_COMPANY_NUMBER))
+                .thenReturn(Optional.ofNullable(EXISTING_UK_ESTABLISHMENT_COMPANY));
+        when(companyProfileRepository.findById(ANOTHER_PARENT_COMPANY_NUMBER))
+                .thenReturn(Optional.empty());
+
+        companyProfileService.deleteCompanyProfile(MOCK_CONTEXT_ID, UK_ESTABLISHMENT_COMPANY_NUMBER, MOCK_DELTA_AT);
+
+        verify(companyProfileRepository).findById(UK_ESTABLISHMENT_COMPANY_NUMBER);
+        verify(companyProfileRepository).findById(ANOTHER_PARENT_COMPANY_NUMBER);
+        verify(companyProfileService).checkForDeleteLinkUkEstablishmentParent(any());
+        verify(companyProfileRepository, times(1)).delete(EXISTING_UK_ESTABLISHMENT_COMPANY);
     }
 
     @Test


### PR DESCRIPTION
* additional check method added in service to delete both if a parent document is found and if not found.
* behaviour before was BR child document would not be deleted if parent already was, which is not desired behaviour.
* if parent document found, uk-establishments link should still be deleted.
* relevant integration tests and service level tests added

all AC on the relevant ticket have been tested locally.

[DSND-3226](https://companieshouse.atlassian.net/browse/DSND-3226)

[DSND-3226]: https://companieshouse.atlassian.net/browse/DSND-3226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ