### PR TITLE
DSND-3095: Remove null fields from stream events

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/company/profile/steps/CompanyProfileSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/steps/CompanyProfileSteps.java
@@ -7,7 +7,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.companieshouse.company.profile.configuration.AbstractMongoConfig.mongoDBContainer;
 

--- a/src/itest/java/uk/gov/companieshouse/company/profile/steps/CompanyProfileSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/profile/steps/CompanyProfileSteps.java
@@ -5,6 +5,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.companieshouse.company.profile.configuration.AbstractMongoConfig.mongoDBContainer;
 
@@ -27,9 +30,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
+import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -39,6 +44,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.FileCopyUtils;
 import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
+import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.company.CompanyDetails;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.company.Data;
@@ -103,6 +109,7 @@ public class CompanyProfileSteps {
     public void chs_kafka_service_unavailable() {
         WiremockTestConfig.stubKafkaApi(HttpStatus.SERVICE_UNAVAILABLE.value());
     }
+
     @When("I send PATCH request with payload {string} and company number {string}")
     public void i_send_put_request_with_payload(String dataFile, String companyNumber) throws IOException {
         WiremockTestConfig.stubKafkaApi(HttpStatus.OK.value());
@@ -276,6 +283,27 @@ public class CompanyProfileSteps {
         verify(0, postRequestedFor(urlEqualTo("/private/resource-changed")));
         List<ServeEvent> serverEvents = WiremockTestConfig.getServeEvents();
         assertTrue(serverEvents.isEmpty());
+    }
+
+    @Then("the CHS Kafka API is invoked successfully for delete for {string}")
+    public void chs_kafka_api_invoked_delete(String dataFile) throws IOException {
+        verify(moreThanOrExactly(1), postRequestedFor(urlEqualTo("/private/resource-changed")));
+
+        File file = new FileSystemResource("src/itest/resources/json/output/" + dataFile + "-resourceChanged.json").getFile();
+        ChangedResource expectedChangedResource = objectMapper.readValue(file, ChangedResource.class);
+
+        List<ServeEvent> serverEvents = WiremockTestConfig.getServeEvents();
+        assertThat(serverEvents).hasSize(1);
+        String requestReceived = serverEvents.getFirst().getRequest().getBodyAsString();
+        ChangedResource actualChangedResource = objectMapper.convertValue(Document.parse(requestReceived), ChangedResource.class);
+
+        assertEquals(expectedChangedResource.getDeletedData(), actualChangedResource.getDeletedData());
+        assertEquals(expectedChangedResource.getResourceUri(), actualChangedResource.getResourceUri());
+        assertEquals(expectedChangedResource.getResourceKind(), actualChangedResource.getResourceKind());
+        assertEquals(expectedChangedResource.getEvent().getType(), actualChangedResource.getEvent().getType());
+
+        String actualDeletedData = actualChangedResource.getDeletedData().toString();
+        assertFalse(actualDeletedData.contains("null"));
     }
 
     @Then("nothing is persisted in the database")

--- a/src/itest/resources/features/delete-company-profile.feature
+++ b/src/itest/resources/features/delete-company-profile.feature
@@ -6,6 +6,7 @@ Feature: Delete company profile
     When a DELETE request is sent to the company profile endpoint for "<company_number>"
     And the company profile does not exist for "<company_number>"
     Then I should receive 200 status code
+    And the CHS Kafka API is invoked successfully for delete for "<data_file>"
 
     Examples:
       | data_file               | company_number |

--- a/src/itest/resources/json/output/with_links_resource-resourceChanged.json
+++ b/src/itest/resources/json/output/with_links_resource-resourceChanged.json
@@ -1,0 +1,117 @@
+{
+  "resource_uri":"/company/00006400",
+  "resource_kind":"company-profile",
+  "context_id":"5234234234",
+  "deleted_data":{
+    "accounts": {
+      "accounting_reference_date": {
+        "day": "31", "month": "08"
+      },
+      "last_accounts": {
+        "made_up_to": "2014-08-31",
+        "period_end_on": "2014-08-31",
+        "period_start_on": "2013-09-01",
+        "type": "group"
+      },
+      "next_accounts": {
+        "due_on": "2016-05-31",
+        "overdue": true,
+        "period_end_on": "2015-08-31",
+        "period_start_on": "2014-09-01"
+      },
+      "next_due": "2016-05-31",
+      "next_made_up_to": "2015-08-31",
+      "overdue": true
+    },
+    "annual_return": {
+      "last_made_up_to": "2015-02-01",
+      "overdue": true
+    },
+    "company_name": "THE GIRLS' DAY SCHOOL TRUST",
+    "company_number": "00006400",
+    "company_status": "active",
+    "confirmation_statement": {
+      "next_due": "2016-02-15",
+      "next_made_up_to": "2016-02-01",
+      "overdue": true
+    },
+    "date_of_creation": "1872-06-26",
+    "etag": "08b54032af094c92e64055007284cf340bd9748f",
+    "has_been_liquidated": false,
+    "has_charges": true,
+    "has_insolvency_history": true,
+    "jurisdiction": "england-wales",
+    "last_full_members_list_date": "2015-02-01",
+    "links": {
+      "persons_with_significant_control": "/company/00006400/persons-with-significant-control",
+      "persons_with_significant_control_statements": "/company/00006400/persons-with-significant-control-statements",
+      "self": "/company/00006400",
+      "filing_history": "/company/00006400/filing-history",
+      "officers": "/company/00006400/officers",
+      "uk_establishments": "/company/00006400/uk-establishments",
+      "exemptions": "/company/00006400/exemptions"
+    },
+    "previous_company_names": [
+      {
+        "ceased_on": "2003-09-01",
+        "effective_from": "1998-04-28",
+        "name": "THE GIRLS' DAY SCHOOL TRUST (1872)"
+      },
+      {
+        "ceased_on": "1998-04-28",
+        "effective_from": "1993-08-25",
+        "name": "THE GIRLS' PUBLIC DAY SCHOOL TRUST (1872)"
+      },
+      {
+        "ceased_on": "1993-08-25",
+        "effective_from": "1872-06-26",
+        "name": "GIRL'S PUBLIC DAY SCHOOL TRUST(THE)"
+      }
+    ],
+    "registered_office_address": {
+      "address_line_1": "100 Rochester Row",
+      "address_line_2": "London",
+      "postal_code": "SW1P 1JP"
+    },
+    "registered_office_is_in_dispute": false,
+    "sic_codes": ["85100", "85200", "85310"],
+    "type": "uk-establishment",
+    "undeliverable_registered_office_address": false,
+    "officer_summary": {
+      "officers": [
+        {
+          "officer_role": "secretary",
+          "name": "HOARE, Caroline Lucy",
+          "appointed_on": "2010-01-22T00:00:00.000Z"
+        },
+        {
+          "officer_role": "director",
+          "name": "CHAKRAVERTY, Julie",
+          "appointed_on": "2013-12-18T00:00:00.000Z"
+        },
+        {
+          "appointed_on": "2015-12-16T00:00:00.000Z",
+          "officer_role": "director",
+          "name": "DAVIS, Kathryn Ruth"
+        },
+        {
+          "officer_role": "director",
+          "name": "DHUT, Rita",
+          "appointed_on": "2016-01-27T00:00:00.000Z"
+        },
+        {
+          "officer_role": "director",
+          "name": "GIBBONS, Kevin Stuart",
+          "appointed_on": "2014-01-22T00:00:00.000Z"
+        }
+      ],
+      "active_count": 12.0,
+      "resigned_count": 54.0
+    }
+  },
+  "event":{
+    "fields_changed":null,
+    "published_at":"2025-02-04T10:53:33",
+    "type":"deleted"
+  }
+}

--- a/src/main/java/uk/gov/companieshouse/company/profile/api/CompanyProfileApiService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/api/CompanyProfileApiService.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.company.profile.api;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;

--- a/src/main/java/uk/gov/companieshouse/company/profile/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/config/ApplicationConfig.java
@@ -5,12 +5,15 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -71,6 +74,17 @@ public class ApplicationConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring().requestMatchers("/company-profile-api/healthcheck");
+    }
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .setDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/company/profile/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/config/ExceptionHandlerConfig.java
@@ -22,6 +22,7 @@ import uk.gov.companieshouse.api.exception.MethodNotAllowedException;
 import uk.gov.companieshouse.api.exception.ResourceStateConflictException;
 import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.company.profile.exception.ConflictException;
+import uk.gov.companieshouse.company.profile.exception.SerDesException;
 import uk.gov.companieshouse.logging.Logger;
 
 
@@ -68,7 +69,7 @@ public class ExceptionHandlerConfig {
      * @param request request.
      * @return error response to return.
      */
-    @ExceptionHandler(value = {Exception.class})
+    @ExceptionHandler(value = {Exception.class, SerDesException.class})
     public ResponseEntity<Object> handleException(Exception ex,
                                                   WebRequest request) {
         return new ResponseEntity<>(responseAndLogBuilderHandler(ex, request),

--- a/src/main/java/uk/gov/companieshouse/company/profile/exception/SerDesException.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/exception/SerDesException.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.company.profile.exception;
+
+public class SerDesException extends RuntimeException {
+
+    public SerDesException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company/profile/api/CompanyProfileApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/api/CompanyProfileApiClientServiceTest.java
@@ -1,9 +1,16 @@
 package uk.gov.companieshouse.company.profile.api;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import java.util.stream.Stream;
@@ -16,7 +23,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.company.Data;
@@ -25,10 +31,14 @@ import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
 import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.company.profile.exception.SerDesException;
 import uk.gov.companieshouse.logging.Logger;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyProfileApiClientServiceTest {
+
+    private static final Data companyData = new Data();
+    private static final Object mappedData = new Data();
 
     @Mock
     private ApiClientService apiClientService;
@@ -48,6 +58,9 @@ class CompanyProfileApiClientServiceTest {
     @Mock
     private Logger logger;
 
+    @Mock
+    private ObjectMapper objectMapper;
+
     @InjectMocks
     private CompanyProfileApiService companyProfileApiService;
 
@@ -56,7 +69,7 @@ class CompanyProfileApiClientServiceTest {
 
         when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
-        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(changedResourcePost);
+        when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(changedResourcePost);
         when(changedResourcePost.execute()).thenReturn(response);
 
         ApiResponse<Void> apiResponse = companyProfileApiService.invokeChsKafkaApi("123456", "CH4000056");
@@ -65,34 +78,40 @@ class CompanyProfileApiClientServiceTest {
 
         verify(apiClientService, times(1)).getInternalApiClient();
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
-        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(any(), any());
         verify(changedResourcePost, times(1)).execute();
     }
 
     @Test
-    void should_invoke_delete_chs_kafka_endpoint_successfully() throws ApiErrorResponseException {
+    void should_invoke_delete_chs_kafka_endpoint_successfully() throws ApiErrorResponseException, JsonProcessingException {
 
         when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
-        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(changedResourcePost);
+        when(objectMapper.writeValueAsString(any())).thenReturn("serialisedData");
+        when(objectMapper.readValue(anyString(), eq(Object.class))).thenReturn(mappedData);
+        when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(changedResourcePost);
         when(changedResourcePost.execute()).thenReturn(response);
 
-        ApiResponse<Void> apiResponse = companyProfileApiService.invokeChsKafkaApiWithDeleteEvent("123456", "CH4000056", new Data());
+        ApiResponse<Void> apiResponse = companyProfileApiService.invokeChsKafkaApiWithDeleteEvent("123456", "CH4000056",
+                companyData);
 
         Assertions.assertThat(apiResponse).isNotNull();
 
         verify(apiClientService, times(1)).getInternalApiClient();
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
-        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
+        verify(objectMapper).writeValueAsString(companyData);
+        verify(objectMapper).readValue("serialisedData", Object.class);
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(any(), any());
         verify(changedResourcePost, times(1)).execute();
     }
 
     @ParameterizedTest
     @MethodSource("provideExceptionParameters")
-    void should_handle_exception_when_chs_kafka_endpoint_throws_appropriate_exception(int statusCode, String statusMessage) throws ApiErrorResponseException {
+    void should_handle_exception_when_chs_kafka_endpoint_throws_appropriate_exception(int statusCode, String statusMessage)
+            throws ApiErrorResponseException {
         when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
-        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(changedResourcePost);
+        when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(changedResourcePost);
 
         HttpResponseException.Builder builder =
                 new HttpResponseException.Builder(statusCode, statusMessage, new HttpHeaders());
@@ -101,19 +120,19 @@ class CompanyProfileApiClientServiceTest {
         when(changedResourcePost.execute()).thenThrow(apiErrorResponseException);
 
         Assert.assertThrows(ServiceUnavailableException.class,
-                () -> companyProfileApiService.invokeChsKafkaApi
-                        ("3245435", "CH4000056"));
+                () -> companyProfileApiService.invokeChsKafkaApi("3245435", "CH4000056"));
 
         verify(apiClientService, times(1)).getInternalApiClient();
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
-        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(),
-                Mockito.any());
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(any(),
+                any());
         verify(changedResourcePost, times(1)).execute();
     }
 
     @ParameterizedTest
     @MethodSource("provideExceptionParameters")
-    void should_handle_exception_when_chs_kafka_delete_endpoint_throws_appropriate_exception(int statusCode, String statusMessage) throws ApiErrorResponseException {
+    void should_handle_exception_when_chs_kafka_delete_endpoint_throws_appropriate_exception(int statusCode, String statusMessage)
+            throws ApiErrorResponseException {
         HttpResponseException.Builder builder =
                 new HttpResponseException.Builder(statusCode, statusMessage, new HttpHeaders());
         ApiErrorResponseException apiErrorResponseException =
@@ -121,18 +140,52 @@ class CompanyProfileApiClientServiceTest {
 
         when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
-        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(changedResourcePost);
+        when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(changedResourcePost);
         when(changedResourcePost.execute()).thenThrow(apiErrorResponseException);
 
         Assert.assertThrows(ServiceUnavailableException.class,
-                () -> companyProfileApiService.invokeChsKafkaApiWithDeleteEvent(
-                        "3245435", "CH4000056", new Data()));
+                () -> companyProfileApiService.invokeChsKafkaApiWithDeleteEvent("3245435", "CH4000056", new Data()));
 
         verify(apiClientService, times(1)).getInternalApiClient();
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
-        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(),
-                Mockito.any());
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(any(),
+                any());
         verify(changedResourcePost, times(1)).execute();
+    }
+
+    @Test
+    void should_handle_exception_when_object_mapper_read_throws_exception() throws JsonProcessingException {
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(objectMapper.writeValueAsString(any())).thenReturn("serialisedData");
+        when(objectMapper.readValue(anyString(), eq(Object.class))).thenThrow(JsonProcessingException.class);
+
+        Assert.assertThrows(SerDesException.class,
+                () -> companyProfileApiService.invokeChsKafkaApiWithDeleteEvent("3245435", "CH4000056", companyData));
+
+        verify(apiClientService).getInternalApiClient();
+        verify(internalApiClient).privateChangedResourceHandler();
+        verify(objectMapper).writeValueAsString(companyData);
+        verify(objectMapper).readValue("serialisedData", Object.class);
+        verifyNoInteractions(privateChangedResourceHandler);
+        verifyNoInteractions(changedResourcePost);
+    }
+
+    @Test
+    void should_handle_exception_when_object_mapper_write_throws_exception() throws JsonProcessingException {
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(objectMapper.writeValueAsString(any())).thenThrow(JsonProcessingException.class);
+
+        Assert.assertThrows(SerDesException.class,
+                () -> companyProfileApiService.invokeChsKafkaApiWithDeleteEvent("3245435", "CH4000056", new Data()));
+
+        verify(apiClientService).getInternalApiClient();
+        verify(internalApiClient).privateChangedResourceHandler();
+        verify(objectMapper).writeValueAsString(companyData);
+        verifyNoMoreInteractions(objectMapper);
+        verifyNoInteractions(privateChangedResourceHandler);
+        verifyNoInteractions(changedResourcePost);
     }
 
     private static Stream<Arguments> provideExceptionParameters() {

--- a/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/controller/CompanyProfileControllerTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpHeaders;
@@ -38,6 +37,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -100,7 +100,7 @@ class CompanyProfileControllerTest {
     private static final String ERIC_PRIVILEGES = "*";
     private static final String ERIC_AUTH = "internal-app";
 
-    @MockBean
+    @MockitoBean
     private Logger logger;
 
     @Autowired
@@ -109,7 +109,7 @@ class CompanyProfileControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private CompanyProfileService companyProfileService;
 
     @InjectMocks
@@ -179,7 +179,7 @@ class CompanyProfileControllerTest {
 
         mockMvc.perform(get(COMPANY_DETAILS_URL).header("ERIC-Identity", ERIC_IDENTITY)
                         .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE))
-                .andExpect(content().string(objectMapper.writeValueAsString(mockCompanyDetailsOP)))
+                .andExpect(content().string(objectMapper.writeValueAsString(mockCompanyDetailsOP.get())))
                 .andExpect(status().isOk());
 
     }


### PR DESCRIPTION
* Add object mapper config
* Serialise/deserialise data before saving to changed resource
* Add new SerDesException and handling for mapper failure cases
* Fix failing tests and add new ones

Resolves [DSND-3095](https://companieshouse.atlassian.net/browse/DSND-3095)

[DSND-3095]: https://companieshouse.atlassian.net/browse/DSND-3095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ