### PR TITLE
Update feature flag for overseas company filing

### DIFF
--- a/src/itest/resources/application-test.yml
+++ b/src/itest/resources/application-test.yml
@@ -11,4 +11,4 @@ chs:
       key: ${CHS_API_KEY:chsApiKey}
 
 feature:
-  overseas-company-filing-allowed: ${FEATURE_FLAG_OVERSEAS_COMPANY_FILING_ALLOWED_08092025:true}
+  overseas-company-filing-disabled: ${FEATURE_FLAG_OVERSEAS_COMPANY_FILING_DISABLED_08092025:false}

--- a/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/company/profile/service/CompanyProfileService.java
@@ -72,8 +72,8 @@ public class CompanyProfileService {
     private final LinkRequestFactory linkRequestFactory;
     private final CompanyProfileTransformer companyProfileTransformer;
 
-    @Value("${feature.overseas-company-filing-allowed}")
-    private boolean isOverseasCompanyFileAllowed;
+    @Value("${feature.overseas-company-filing-disabled}")
+    private boolean isOverseasCompanyFileDisabled;
 
     /**
      * Constructor.
@@ -485,7 +485,7 @@ public class CompanyProfileService {
                     || companyType.equals("llp")
                     || companyType.equals("plc")
                     || companyType.contains("private")
-                    || (companyType.equals("oversea-company") && isOverseasCompanyFileAllowed)) {
+                    || (companyType.equals("oversea-company") && !isOverseasCompanyFileDisabled)) {
                 companyProfile.setCanFile(!companyStatus.equals("dissolved")
                         && !companyStatus.equals("converted-closed")
                         && !companyStatus.equals("petition-to-restore-dissolved"));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,4 +37,4 @@ management:
       enabled: true
 
 feature:
-  overseas-company-filing-allowed: ${FEATURE_FLAG_OVERSEAS_COMPANY_FILING_ALLOWED_08092025:false}
+  overseas-company-filing-disabled: ${FEATURE_FLAG_OVERSEAS_COMPANY_FILING_DISABLED_08092025:false}

--- a/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/profile/service/CompanyProfileServiceTest.java
@@ -93,8 +93,8 @@ import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyProfileServiceTest {
-    private static final String IS_OVERSEAS_COMPANY_FILE_ALLOWED_FIELD = "isOverseasCompanyFileAllowed";
-    private static final boolean IS_OVERSEAS_COMPANY_FILE_ALLOWED = true;
+    private static final String IS_OVERSEAS_COMPANY_FILE_DISABLED_FIELD = "isOverseasCompanyFileDisabled";
+    private static final boolean IS_OVERSEAS_COMPANY_FILE_DISABLED = false;
     private static final String MOCK_COMPANY_NUMBER = "6146287";
     private static final String MOCK_CONTEXT_ID = "123456";
     private static final String MOCK_PARENT_COMPANY_NUMBER = "321033";
@@ -176,9 +176,9 @@ class CompanyProfileServiceTest {
 
     @BeforeEach
     void beforeEach() throws NoSuchFieldException, IllegalAccessException {
-        var field = CompanyProfileService.class.getDeclaredField(IS_OVERSEAS_COMPANY_FILE_ALLOWED_FIELD);
+        var field = CompanyProfileService.class.getDeclaredField(IS_OVERSEAS_COMPANY_FILE_DISABLED_FIELD);
         field.setAccessible(true);
-        field.set(companyProfileService, IS_OVERSEAS_COMPANY_FILE_ALLOWED);
+        field.set(companyProfileService, IS_OVERSEAS_COMPANY_FILE_DISABLED);
     }
 
     @Test


### PR DESCRIPTION
Update feature flag for overseas company filing to use 'disabled' instead of 'allowed'