### PR TITLE
Fix security vulnerabilities reported in the Dep check & upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
-        <spring-boot-starter.version>3.4.5</spring-boot-starter.version>
-        <spring-context.version>6.2.7</spring-context.version>
-        <spring-security-core.version>6.5.0</spring-security-core.version>
+        <spring-boot-starter.version>3.5.3</spring-boot-starter.version>
+        <spring-context.version>6.2.11</spring-context.version>
+        <spring-security-core.version>6.5.4</spring-security-core.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
-        <tomcat-embed-core.version>11.0.8</tomcat-embed-core.version>
+        <tomcat-embed-core.version>11.0.10</tomcat-embed-core.version>
         <spring-web.version>6.2.8</spring-web.version>
 
         <main.class>uk.gov.companieshouse.company.profile.CompanyProfileApiApplication</main.class>
@@ -38,8 +38,8 @@
 
         <!-- tests -->
         <cucumber-java.version>7.20.1</cucumber-java.version>
-        <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>3.5.1</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
 


### PR DESCRIPTION
Upgraded the following dependencies

  - tomcat-embed-core to 11.0.10
  - maven-surefire-plugin → 3.5.3
  - maven-failsafe-plugin → 3.5.3
  - spring-boot-starter → 3.5.3
  - spring-context → 6.2.11
  - spring-security-core → 6.5.4